### PR TITLE
Give Redocusaurus its own page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-This repo contains the documentation for [MilMove](https://github.com/transcom/mymove), a possible next generation version of the Defense Personal Property System (DPS). DPS is an online system managed by the U.S. [Department of Defense](https://www.defense.gov/) (DoD) [Transportation Command](http://www.ustranscom.mil/) (USTRANSCOM) and is used by service members and their families to manage household goods moves. 
+This repo contains the documentation for [MilMove](https://github.com/transcom/mymove), a possible next generation version of the Defense Personal Property System (DPS). DPS is an online system managed by the U.S. [Department of Defense](https://www.defense.gov/) (DoD) [Transportation Command](http://www.ustranscom.mil/) (USTRANSCOM) and is used by service members and their families to manage household goods moves.
 
 This website is created using [Docusaurus](https://docusaurus.io/), a React-based static site generator. Information about running and testing the MilMove app, and coding against its APIs, is located here. If you have questions or notice inaccuracies, feel to either (if you are on the project) edit the docs directly or (if you an external contractor) open an issue regarding the problem.
 
@@ -17,8 +17,8 @@ This website is created using [Docusaurus](https://docusaurus.io/), a React-base
 
 ## Running locally (on MacOS)
 
-1. Open your terminal/command line. 
-2. Clone the repo onto your machine: 
+1. Open your terminal/command line.
+2. Clone the repo onto your machine:
    ```
    git clone https://github.com/transcom/mymove-docs.git
    ```
@@ -40,36 +40,36 @@ This website is created using [Docusaurus](https://docusaurus.io/), a React-base
    yarn install
    ```
    - If you need to install `yarn`, first check if you have Homebrew, the MacOS package/software manager: `which brew`
-      - If you don't get a response, you need to install it: 
+      - If you don't get a response, you need to install it:
          ```
          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
          ```
    - Then check if you have `node` or `nodenv`: `which node`, `which nodenv`
-      - If you have `node`, continue on. If not, first install `nodenv`: 
+      - If you have `node`, continue on. If not, first install `nodenv`:
          ```
          brew install nodenv
          ```
-      - Add `nodenv` to your terminal configuration file: 
+      - Add `nodenv` to your terminal configuration file:
          ```
          echo 'eval "$(nodenv init -)"' >> ~/.bashrc
          ```
-      - Reset your terminal configuration: 
+      - Reset your terminal configuration:
          ```
          source ~/.bashrc
          ```
-      - Install a version of `node` that is 12 or above (I recommend [the same version we use on MilMove](https://github.com/transcom/mymove/blob/master/.node-version)): 
+      - Install a version of `node` that is 12 or above (I recommend [the same version we use on MilMove](https://github.com/transcom/mymove/blob/master/.node-version)):
          ```
          nodenv install <version>
          ```
-      - Then set the global version to the one you installed: 
+      - Then set the global version to the one you installed:
          ```
          nodenv global <version>
          ```
-   - Finally, install `yarn`: 
+   - Finally, install `yarn`:
       ```
       npm install --global yarn
       ```
-   - Now you should be able to run the local site! If you're still having trouble, try adding `npx` to the start of every `yarn` command: 
+   - Now you should be able to run the local site! If you're still having trouble, try adding `npx` to the start of every `yarn` command:
       ```
       npx yarn install
       ```
@@ -79,23 +79,10 @@ This website is created using [Docusaurus](https://docusaurus.io/), a React-base
 
 ## Deployment
 
-This site is currently deployed using GitHub pages: https://transcom.github.io/mymove-docs/. We're using GitHub actions to redeploy whenever changes are merged to the main branch, which includes all commits that are made and saved directly in GitHub. 
+This site is currently deployed using GitHub pages: https://transcom.github.io/mymove-docs/. We're using GitHub actions to redeploy whenever changes are merged to the main branch, which includes all commits that are made and saved directly in GitHub.
 
-Be aware that GitHub pages has a _soft_ limit of 10 deploys per hour, and it is possible we could run up against this (read more about the limitations of pages here: [About GitHub Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#usage-limits)). It should not have a significant affect on our day-to-day activities, however, and may never become a noticeable issue. 
-## Open API / Swagger API documentation
+Be aware that GitHub pages has a _soft_ limit of 10 deploys per hour, and it is possible we could run up against this (read more about the limitations of pages here: [About GitHub Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#usage-limits)). It should not have a significant affect on our day-to-day activities, however, and may never become a noticeable issue.
 
-This site leverages the [Redocusaurus plugin][gh-redocusaurus] to add embedded
-support for documentation related to the Open API / Swagger API documentation
-within the `trancom/mymove` repository.
+## API Documentation
 
-The way the preset works is by leveraging the raw GitHub URLs for the YAML files
-found in `transcom/mymove`. This means that the API documentation on this site
-will only contain the latest changes that are available in the default branch
-for the `transcom/mymove` repository.
-
-You can see this in the `./docusaurus.config.js` file under the `presets` named
-`redocusaurus`. For more information, [see the documentation around setting
-things up][redocusaurus-docs].
-
-[redocusaurus-docs]: https://github.com/rohit-gohri/redocusaurus/tree/main/packages/redocusaurus
-[gh-redocusaurus]: https://github.com/rohit-gohri/redocusaurus
+[Please read more about Redocusaurus is being used for API documentation.](https://transcom.github.io/mymove-docs/docs/dev/tools/redocusaurus)

--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ Be aware that GitHub pages has a _soft_ limit of 10 deploys per hour, and it is 
 
 ## API Documentation
 
-[Please read more about Redocusaurus is being used for API documentation.](https://transcom.github.io/mymove-docs/docs/dev/tools/redocusaurus)
+[Please read more about how Redocusaurus is being used for API documentation.](https://transcom.github.io/mymove-docs/docs/dev/tools/redocusaurus)

--- a/docs/dev/tools/redocusaurus.md
+++ b/docs/dev/tools/redocusaurus.md
@@ -1,0 +1,124 @@
+---
+title: Redocusaurus
+---
+
+:::tip
+
+This documentation is helpful for anyone editing documentation related to the
+Swagger API definitions. It is helpful to understand those concepts first before
+diving into this documentation.
+
+:::
+
+:::caution
+
+This documentation leverages multiple projects that could lead to confusing
+error messages and warnings. For help, please reach out in
+[#wg-documentation][slack-wg-documentation]🔒 if you get stuck.
+
+[slack-wg-documentation]: https://ustcdp3.slack.com/archives/C027BDJ4678
+
+:::
+
+## What is Redocusaurus?
+
+[Redocusaurus][gh-redocusaurus] is a preset for Docusaurus. See [the packages
+documentation][redocusaurus-docs] for more general information about
+Redocusaurus. The purpose of this documentation is to help MilMove developers
+understand how the preset is integrated into Docusaurus and how to work with it
+locally.
+
+[redocusaurus-docs]: https://github.com/rohit-gohri/redocusaurus/tree/main/packages/redocusaurus
+[gh-redocusaurus]: https://github.com/rohit-gohri/redocusaurus
+
+## Redocusaurus configuration
+
+The presets for Docusaurus are set in the `docusaurus.config.js` file in the
+`transcom/mymove-docs` repository. See [the official Docusaurus
+documentation][doc-preset] on using presets for more general information.
+
+[doc-preset]: https://docusaurus.io/docs/presets
+
+:::info
+
+The way `transcom/mymove-docs` uses this is by leveraging the raw GitHub URLs
+for the Yaml files found in `transcom/mymove`. This means the API documentation
+is in sync with the default branch for the `transcom/mymove` repository. This
+means that until your Swagger file changes are merged into the default branch of
+`transcom/mymove` you cannot view the changes in the `transcom/mymove-docs`
+repository.
+
+:::
+
+You can see this in the `./docusaurus.config.js` file under the `presets` named
+`redocusaurus`.
+
+## Working with local changes to Swagger files
+
+To view changes to the Swagger documentation locally with Docusaurus, you need
+to have both repositories cloned on your machine. While you will be working with
+two repositories, the actual commits associated with these changes will happen
+in the `transcom/mymove` repository and not in the `trancom/mymove-docs`
+repository.
+
+### The two repositories
+
+- https://github.com/transcom/mymove
+- https://github.com/transcom/mymove-docs
+
+### Updating the Docusaurus configuration
+
+Once you have these repositories cloned locally, you will need to edit the
+`documentation.config.js` file to leverage the `spec:` property instead of the
+`specUrl` property.
+
+The Git patch below shows what these changes would look like locally. The main
+thing to consider here is the location of the Swagger specification. In the
+example below, it is relative to the `transcom/mymove-docs` repository.
+
+```diff title="Updates to specification paths" {9,10,14,15}
+diff --git a/docusaurus.config.js b/docusaurus.config.js
+index 697ffef..30fdcc4 100644
+--- a/docusaurus.config.js
++++ b/docusaurus.config.js
+@@ -144,11 +144,11 @@ module.exports = {
+       {
+         specs: [
+           {
+-            specUrl: 'https://raw.githubusercontent.com/transcom/mymove/master/swagger/prime.yaml',
++            spec: '../mymove/swagger/prime.yaml',
+             routePath: '/api/prime',
+           },
+           {
+-            specUrl: 'https://raw.githubusercontent.com/transcom/mymove/master/swagger/support.yaml',
++            spec: '../mymove/swagger/support.yaml',
+             routePath: '/api/support',
+           },
+         ],
+```
+
+### Viewing changes in local Docusaurus
+
+Now that you have updated the `docusaurus.config.js` with the changes mentioned
+above, you will need to edit Swagger files found in `transcom/mymove` under
+`swagger-def/` and then run the `make swagger_generate` command in order for
+them to show up in Docusaurus.
+
+You will have to repeat this section for every change to the Swagger files. Make
+sure you have the `transcom/mymove-docs` server running locally. Whenever there
+are changes to the `trancom/mymove/swagger/*.yaml` files mentioned above,
+Docusaurus will helpfully reload the page. Because of interconnectedness of
+different technology, you may have to run the `make swagger_generate` command
+more than once if the changes aren't being reflected in your local Docusaurus
+API page.
+
+## Undoing local configuration for Redocusaurus
+
+If the only changes that were made to `docusaurus.config.js` are related to the
+Redocusaurus, you can easily discard these changes using the following Git
+command in the terminal. Please make sure you do this after you've committed
+changes in `transcom/mymove` which are related to the Swagger documentation.
+
+```sh
+git checkout -- docusaurus.config.js
+```


### PR DESCRIPTION
I'm doing this because I found that working with Swagger and
Redocusaurus locally isn't difficult, but it is complex enough to have
documentation on.

Apologies in advance for the changes to the README.md file. I will
highlight the only change to that document that I made in a comment.
The other changes are the removal of empty spaces which my editor
does automatically.