### PR TITLE
Change the port

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "docusaurus start --port 4000",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
-    "serve": "docusaurus serve",
+    "serve": "docusaurus serve --port 4000",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids"
   },


### PR DESCRIPTION
I'm changing the port to `4000` because it collides with the port set
for the `transcom/mymove` front-end and if people are running everything
locally they're going to get stuck in a state where they can't run the
projects without seeing errors/warnings.