### PR TITLE
MB-9620-edit-enpoint-docs

### DIFF
--- a/docs/dev/contributing/backend/Guide-to-Creating-an-Endpoint.md
+++ b/docs/dev/contributing/backend/Guide-to-Creating-an-Endpoint.md
@@ -188,6 +188,7 @@ Additionally in your file containing the handler make sure to pass in the servic
    
         
 #### How to handle errors
+TODO: WIP
 ### Add event key and update event map
 Each API has a corresponding file in `/pkg/services/event/<apiName>_endpoint.go`
 1. Add new `const` to represent event key

--- a/docs/dev/contributing/backend/Guide-to-Creating-an-Endpoint.md
+++ b/docs/dev/contributing/backend/Guide-to-Creating-an-Endpoint.md
@@ -197,3 +197,11 @@ An example of an event key for MoveTaskOrder Create Handler is as follows:
 
     // MoveTaskOrderCreateEventKey is a key containing MoveTaskOrder.Create
     const MoveTaskOrderCreateEventKey KeyType = "MoveTaskOrder.Create"
+
+The event would be added to the event map called eventModels:
+    
+    var eventModels = map[KeyType]eventModel{
+    	EndpointEventKey:                    {EndpointEventKey, models.Model{}}, // this is an example
+    	NewEndpointEventKey:                 {NewEndpointEventKey, models.Model{}}, // this is an example
+    	MoveTaskOrderCreateEventKey:         {MoveTaskOrderCreateEventKey, models.Move{}},
+        

--- a/docs/dev/contributing/backend/Guide-to-Creating-an-Endpoint.md
+++ b/docs/dev/contributing/backend/Guide-to-Creating-an-Endpoint.md
@@ -2,33 +2,198 @@ These are the various steps that are involved in creating a new endpoint.
 
 It was written for external facing APIs, rather than internal ones. But most concepts should apply equally to internal APIs.
 
-This page is a skeleton that we hope to populate with more details. 
+Prior to creating adding an endpoint to the Handler folder, we must first add a new endpoint definition to swagger. We are using Swagger 2.0, which is [OpenAPI](https://swagger.io/specification/v2/), a specification we use to format our RESTful APIs and provide a template for us to communicate the information in our API.
+Always start with swagger. This step creates your endpoint definition and generates the files and helper functions you will need to create your endpoint. More specifically, swagger converts JSON user input into generated Go types.
+## Adding  a new entry into the yaml
+All new definitions will be added in `mymove/swagger-def`. Note that we have broken down our spec into different files and we share definitions between files. 
+Built compiled versions of our API spec will be generated and stored in the swagger folder, which we will not edit directly. Notice that there is a yaml file for each of our APIs. 
+An endpoint definition for the prime will likely go into the Prime yaml, but you may notice there are some definitions in `mymove/swagger-def/definitions`.
+This is because some definitions are shared across APIs and we've created a space to add those definitions in one place. 
 
-* Add a new entry into the yaml
-	* URL design and structure: [API Style Guide](https://github.com/transcom/mymove/wiki/API-Style-Guide)
-	* Path Parameters, Headers and Body 
-	* Response Body
-		* Required
-		* x-nullable
-		* Readonly
-		* Documentation
-	* Error Responses: [API Errors Guide](https://github.com/transcom/mymove/wiki/API-Errors)
-* Add a handler for the endpoint
-	* Add payload_to_model and model_to_payload functions
-	* Create handler type and Handle function
-		* Hook it up to api.go
-	* How to handle errors
-* Add service object
-	* When to make a service object: [Service Objects](https://github.com/transcom/mymove/wiki/service-objects)
-	* Add service object interface
-	* Add service object constructor
-	* Add service object code
-	* Add service object tests
-* Add event key and update event map
-	* Each API has a corresponding file in `/pkg/services/event/<apiName>_endpoint.go`
-	* Add new `const` to represent event key
-	* Add event key to endpoint map in the same file, using the event key name, api name, and operation ID.
-* Add tests for the handler
-	* Add mocks: [Generating Mocks with mockery](https://github.com/transcom/mymove/wiki/generate-mocks-with-mockery)
-	* Add test code
-        * Use testdatagen functions [[Understanding Testdatagen Functions]]
+For the purposes for adding a new endpoint, make sure that your endpoint is defined in these top level sections:
+* `tags` - is where we group all of our endpoints by category (i.e. shipment endpoints, agent endpoints, service item endpoints, etc.). 
+         This top level field is where our gen files will divide the endpoints into their own packages. Tag component names are `camelCase`.
+* `paths` - defines our endpoint. Path names use `kebab-case`.
+* `definitions` - defines the shape of the data for our endpoint. Definitions component names are `PascalCase`.
+* `responses` - define what the endpoints return. Responses component names are `PascalCase`.
+* `parameters` - define what an endpoint needs (e.g. headers). Parameter component names are `camelCase`.
+
+#### Defining a path for your endpoint 
+For more information about URL design and structure checkout: [API Style Guide](https://github.com/transcom/mymove/wiki/API-Style-Guide)
+
+Defining your endpoint path follows this simple convention:
+
+        /your path:
+            HTTP request:
+                summary:
+                description:
+                operationId: this should match the endpoint title in the definitions section and summary in your paths section.
+                tags: matches the tag section for this endpoint
+                produces: This field will always be application/json
+                parameters: Include parameters associated with this path
+                responses: response codes for this path, and a schema reference and the description if needed.
+                
+An example of the `Moves` path is as follows:
+
+      /moves:
+        get:
+          summary: listMoves
+          description: |
+            Gets all moves that have been reviewed and approved by the TOO. 
+          operationId: listMoves
+          tags:
+            - moveTaskOrder
+          produces:
+            - application/json
+          parameters:
+            - in: query
+              name: since
+              type: string
+              format: date-time
+              description: Only return moves updated since this time. Formatted like "2021-07-23T18:30:47.116Z"
+          responses:
+            '200':
+              description: Successfully retrieved moves. A successful fetch might still return zero moves.
+              schema:
+                $ref: '#/definitions/ListMoves'
+            '401':
+              $ref: 'responses/PermissionDenied.yaml'
+            '403':
+              $ref: 'responses/PermissionDenied.yaml'
+            '500':
+              $ref: '#/responses/ServerError'
+        
+#### Description Section and the response body
+In your endpoint description make sure that the following fields are included when necessary:
+* required - fields that are required are listed in the description section.
+* x-nullable - this indicates that the value of a particular property may be null. 
+* readOnly - sometimes you will need specify a readyonly property, for example when the property differs in a GET from a POST or PATCH. Note: readOnly properties are included in responses but not in requests.
+* eTag - An entity tag is provided so that a browser client or a script can make conditional REST requests using optimistic concurrency control. All eTags must be marked as readOnly.
+
+An example of the ListMove description is as follows:
+        
+          ListMove:
+            description: >
+              An abbreviated definition for a move, without all the nested information (shipments, service items, etc). Used to
+              fetch a list of moves more efficiently.
+            type: object
+            properties:
+              id:
+                example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+                format: uuid
+                type: string
+              moveCode:
+                type: string
+                example: 'HYXFJF'
+                readOnly: true
+              createdAt:
+                format: date-time
+                type: string
+                readOnly: true
+              orderID:
+                example: c56a4180-65aa-42ec-a945-5fd21dec0538
+                format: uuid
+                type: string
+              referenceId:
+                example: 1001-3456
+                type: string
+              availableToPrimeAt:
+                format: date-time
+                type: string
+                x-nullable: true
+                readOnly: true
+              updatedAt:
+                format: date-time
+                type: string
+                readOnly: true
+              ppmType:
+                type: string
+                enum:
+                  - FULL
+                  - PARTIAL
+              ppmEstimatedWeight:
+                type: integer
+              eTag:
+                type: string
+                readOnly: true
+
+For information on error responses, check out: [API Errors Guide](https://github.com/transcom/mymove/wiki/API-Errors)
+
+#### Gen files:
+Once you finishing updating the yaml files with the new endpoint information make sure to run your make commands to autogenerate your swagger files, or simply run `make server_run`, 
+which runs your server and other useful make commands in one go.
+
+## Creating an endpoint. 
+Now you're ready to add your endpoint to the `handlers` folder. Start building out the service object before creating your handler. 
+For more information about service objects and when to create one: [Service Objects](https://github.com/transcom/mymove/wiki/service-objects).
+
+An important note about service objects: The service layer is where we will store our business logic and connect to the database. Once a service object is created, it will be passed in to the handler `NewPrimeAPIHandler` function in `pkg/handlers/primeapi/api.go`,
+and the handler will only be aware of the service object interface, while the service object will contain all of the rules and validations as well as accessing object from the database.
+
+Handlers must never hit the database. Ideally, endpoint handlers are for type validations.
+
+#### Steps to creating a new handler:
+1. Add a handler for the endpoint
+2. Add payload_to_model converters
+    * this is a good place to check data types and null values.
+3. model_to_payload functions
+    * Once we have either modified the model or added something to our model, it must be converted back into a payload in order to be returned by the handler.
+4. Create handler type and Handle function
+5. Add tests for the handler
+   	* Add test code
+           * Use testdatagen functions [[Understanding Testdatagen Functions]]
+    * Add mocks (only if absolutely necessary): [Generating Mocks with mockery](https://github.com/transcom/mymove/wiki/generate-mocks-with-mockery)
+	
+Here is an example of what the `ListMovesHandler` will look like:
+
+    // Handle fetches all moves with the option to filter since a particular date. Optimized version.
+    func (h ListMovesHandler) Handle(params movetaskorderops.ListMovesParams) middleware.Responder {
+    	logger := h.LoggerFromRequest(params.HTTPRequest)
+    	appCtx := appcontext.NewAppContext(h.DB(), logger)
+    
+    	var searchParams services.MoveTaskOrderFetcherParams
+    	if params.Since != nil {
+    		since := handlers.FmtDateTimePtrToPop(params.Since)
+    		searchParams.Since = &since
+    	}
+    
+    	mtos, err := h.MoveTaskOrderFetcher.ListPrimeMoveTaskOrders(appCtx, &searchParams)
+    
+    	if err != nil {
+    		logger.Error("Unexpected error while fetching moves:", zap.Error(err))
+    		return movetaskorderops.NewListMovesInternalServerError().WithPayload(payloads.InternalServerError(nil, h.GetTraceID()))
+    	}
+    
+    	payload := payloads.ListMoves(&mtos)
+    
+    	return movetaskorderops.NewListMovesOK().WithPayload(payload)
+    }
+
+	
+#### Connecting the Handler to the Service Object:
+Once you create your handler type and Handle function, it can be added to api.go. This file is also where you can connect your service object to the handler. 
+For example, our ListsMoves Handler will be passed the service object interface as follows:
+
+    primeAPI.MoveTaskOrderListMovesHandler = ListMovesHandler{
+        ctx,
+        movetaskorder.NewMoveTaskOrderFetcher(),
+    }
+    	
+Additionally in your file containing the handler make sure to pass in the services to your struct:
+    
+    type ListMovesHandler struct {
+    	handlers.HandlerContext
+    	services.MoveTaskOrderFetcher
+    }
+   
+        
+#### How to handle errors
+### Add event key and update event map
+Each API has a corresponding file in `/pkg/services/event/<apiName>_endpoint.go`
+1. Add new `const` to represent event key
+2. Add event key to endpoint map in the same file, using the event key name, api name, and operation ID.
+
+An example of an event key for MoveTaskOrder Create Handler is as follows:
+
+    // MoveTaskOrderCreateEventKey is a key containing MoveTaskOrder.Create
+    const MoveTaskOrderCreateEventKey KeyType = "MoveTaskOrder.Create"


### PR DESCRIPTION
The purpose of this PR is to update the Endpoint documentation in Docusaurus with more detailed information (i.e. steps to creating an endpoint) and technical examples.

### Feedback request
I need to add more context to the event maps section at the end. I'd like to help locating useful records of information we've recorded around event maps for this project.