### PR TITLE
[MB-9756] Update location of new top-level apperror package

### DIFF
--- a/docs/dev/contributing/backend/API-Errors.md
+++ b/docs/dev/contributing/backend/API-Errors.md
@@ -78,7 +78,7 @@ mtoshipmentops.NewCreateMTOShipmentNotFound().WithPayload(payload)
 
 ### Error types and Error responses
 
-Error types in the code are defined in `pkg/services/errors.go`.
+Error types in the code are defined in `pkg/apperror/errors.go`.
 
 Error responses are defined in the yamls, `swagger/prime.yaml` and `swagger/support.yaml`
 


### PR DESCRIPTION
Changes introduced in https://github.com/transcom/mymove/pull/7593 moved the errors that used to be in pkg/services/errors to a top-level apperror package.