### PR TITLE
Add support for golang alias in code blocks

### DIFF
--- a/src/components/prism-golang.js
+++ b/src/components/prism-golang.js
@@ -1,0 +1,12 @@
+Prism.languages.golang = Prism.languages.extend('clike', {
+  'string': {
+    pattern: /(["'`])(?:\\[\s\S]|(?!\1)[^\\])*\1/,
+    greedy: true
+  },
+  'keyword': /\b(?:break|case|chan|const|continue|default|defer|else|fallthrough|for|func|go(?:to)?|if|import|interface|map|package|range|return|select|struct|switch|type|var)\b/,
+  'boolean': /\b(?:_|false|iota|nil|true)\b/,
+  'number': /(?:\b0x[a-f\d]+|(?:\b\d+(?:\.\d*)?|\B\.\d+)(?:e[-+]?\d+)?)i?/i,
+  'operator': /[*\/%^!=]=?|\+[=+]?|-[=-]?|\|[=|]?|&(?:=|&|\^=?)?|>(?:>=?|=)?|<(?:<=?|=|-)?|:=|\.\.\./,
+  'builtin': /\b(?:append|bool|byte|cap|close|complex|complex(?:64|128)|copy|delete|error|float(?:32|64)|u?int(?:8|16|32|64)?|imag|len|make|new|panic|print(?:ln)?|real|recover|rune|string|uintptr)\b/
+});
+delete Prism.languages.golang['class-name'];

--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+import siteConfig from '@generated/docusaurus.config';
+
+const prismIncludeLanguages = (PrismObject) => {
+  if (ExecutionEnvironment.canUseDOM) {
+    const {
+      themeConfig: {prism = {}},
+    } = siteConfig;
+    const {additionalLanguages = []} = prism;
+    window.Prism = PrismObject;
+    additionalLanguages.forEach((lang) => {
+      require(`prismjs/components/prism-${lang}`); // eslint-disable-line
+    });
+
+    require('/src/components/prism-golang.js');
+
+    delete window.Prism;
+  }
+};
+
+export default prismIncludeLanguages;


### PR DESCRIPTION
Currently, Docusaurus, by way of PrismJS, only supports the `go` alias
for syntax highlighting code blocks. For example, this will result in
the code being highlighted:

```
```go
```

but this will not:

```
```golang
```

In my case, I use Sublime Text, and the Markdown plugin I use only
highlights the code in my editor using the `golang` alias. We also have
many instances of the `golang` alias in the code blocks in this repo
because that's what we used in the GitHub Wiki.

PrismJS allows adding aliases to existing languages, but that would
require submitting a PR to the Prism repo, and I'm not sure how long it
would take for them to merge it.

Alternatively, Docusaurus allows you to define additional languages,
which is easy, and is what I did in this PR. Per the instructions, I ran

```
yarn run swizzle @docusaurus/theme-classic prism-include-languages
```
which created the `prism-include-languages.js` file, to which I added
`require('/src/components/prism-golang.js');`, and then I created the
`prism-golang.js` file, and copied and pasted the Go definition from the
Prism repo, and replace `go` with `golang`.

References:
https://docusaurus.io/docs/markdown-features/code-blocks#supported-languages
https://prismjs.com/extending.html#creating-a-new-language-definition
https://github.com/PrismJS/prism/blob/master/components/prism-go.js

To test this, visit https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/API-Errors
and go all the way at the bottom. Notice how the last code block is not
highlighted. Now, run this PR locally, and open that same file, and
notice how it is highlighted now.
