### PR TITLE
Remove redundant redirects

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -172,18 +172,6 @@ module.exports = {
       {
         redirects: [
           {
-            to: '/docs/about/overview-of-milmove',
-            from: [
-              '/docs/about/Overview-of-Milmove',
-            ],
-          },
-          {
-            to: '/docs/about/security/user-management',
-            from: [
-              '/docs/about/security/User-Management',
-            ],
-          },
-          {
             to: '/docs/frontend/testing/frontend',
             from: [
               '/docs/dev/contributing/frontend/frontend',


### PR DESCRIPTION
<details>
<summary>This originally broke the build with this message</summary>

```sh
>_ Server cache (99%) shutdown IdleFileCachePlugin
 stored

[Local Search] [INFO]: Gathering documents
[Local Search] [INFO]: Parsing documents
Unable to build website for locale "en".
Error: Redirect file creation error for "~/Developer/tmp/mymove-docs/build/docs/about/Overview-of-Milmove/index.html" path: Error: The redirect plugin is not supposed to override existing files..
    at writeRedirectFile (~/Developer/tmp/mymove-docs/node_modules/@docusaurus/plugin-client-redirects/lib/writeRedirectFiles.js:78:15)
    at async Promise.all (index 0)
    at async Object.writeRedirectFiles [as default] (~/Developer/tmp/mymove-docs/node_modules/@docusaurus/plugin-client-redirects/lib/writeRedirectFiles.js:83:5)
    at async Object.postBuild (~/Developer/tmp/mymove-docs/node_modules/@docusaurus/plugin-client-redirects/lib/index.js:29:13)
    at async ~/Developer/tmp/mymove-docs/node_modules/@docusaurus/core/lib/commands/build.js:158:9
    at async Promise.all (index 9)
    at async buildLocale (~/Developer/tmp/mymove-docs/node_modules/@docusaurus/core/lib/commands/build.js:154:5)
    at async tryToBuildLocale (~/Developer/tmp/mymove-docs/node_modules/@docusaurus/core/lib/commands/build.js:32:20)
    at async Object.mapAsyncSequencial (~/Developer/tmp/mymove-docs/node_modules/@docusaurus/utils/lib/index.js:263:24)
    at async build (~/Developer/tmp/mymove-docs/node_modules/@docusaurus/core/lib/commands/build.js:68:25)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
</details>


This should fix the build going forward.