### PR TITLE
Clarify GOROOT troubleshooting for asdf and don't hardcode env value

### DIFF
--- a/docs/backend/guides/how-to/manage-golang-with-asdf.md
+++ b/docs/backend/guides/how-to/manage-golang-with-asdf.md
@@ -91,7 +91,7 @@ OK: all prereqs found
 
 ### GOROOT is showing a different version or not working with GoLand
 
-Another issue GoLand users and others can run into with asdf is with GOROOT. Goland expects GOROOT to be set but it may be unclear what it should be set to. You can easily find the value by running `asdf where go`. Not upgrading versions will require this to change unless you can set GOROOT to the output directory of `asdf where go`. For example, you can set this in your `~/.zshrc` (or similar) shell:
+Another issue GoLand users and others can run into with asdf is with GOROOT. Goland expects GOROOT to be set but it may be unclear what it should be set to. You can easily find the value by running `asdf where golang`. Not upgrading versions will require this to change unless you can set GOROOT to the output directory of `asdf where golang`. For example, you can set this in your `~/.zshrc` (or similar) shell:
 
 ```sh
 export GOROOT="$(asdf where golang)/go/"

--- a/docs/backend/guides/how-to/manage-golang-with-asdf.md
+++ b/docs/backend/guides/how-to/manage-golang-with-asdf.md
@@ -91,7 +91,7 @@ OK: all prereqs found
 
 ### GOROOT is showing a different version or not working with GoLand
 
-Another issue GoLand users and others can run into with asdf is with GOROOT. Goland expects GOROOT to be set but it may be unclear what it should be set to. You can easily find the value by running `asdf where go` and then set that appropriately for your shell. Not upgrading versions will require this to change unless you can set GOROOT to the output directory of `asdf where go`, for example
+Another issue GoLand users and others can run into with asdf is with GOROOT. Goland expects GOROOT to be set but it may be unclear what it should be set to. You can easily find the value by running `asdf where go`. Not upgrading versions will require this to change unless you can set GOROOT to the output directory of `asdf where go`. For example, you can set this in your `~/.zshrc` (or similar) shell:
 
 ```sh
 export GOROOT="$(asdf where golang)/go/"

--- a/docs/backend/guides/how-to/manage-golang-with-asdf.md
+++ b/docs/backend/guides/how-to/manage-golang-with-asdf.md
@@ -89,12 +89,12 @@ OK: all prereqs found
 
 ## Troubleshooting
 
-### GoLand is looking for GOROOT
+### GOROOT is showing a different version or not working with GoLand
 
-Another issue GoLand users can run into with asdf is with GOROOT. Goland expects GOROOT to be set but it may be unclear what it should be set to. You can easily find the value by running `asdf which go` and then set that appropriately for your shell. Not upgrading versions will require this to change unless you can set GOROOT to the output directory of `asdf which go`, for example
+Another issue GoLand users and others can run into with asdf is with GOROOT. Goland expects GOROOT to be set but it may be unclear what it should be set to. You can easily find the value by running `asdf where go` and then set that appropriately for your shell. Not upgrading versions will require this to change unless you can set GOROOT to the output directory of `asdf where go`, for example
 
 ```sh
-export GOROOT=~/.asdf/installs/golang/1.15.10/go
+export GOROOT="$(asdf where golang)/go/"
 ```
 
 ### Missing `asdf.sh` executable


### PR DESCRIPTION
While trying to run the standalone ato-linter tool I was having what looked like go build/version issues with types and packages.  I knew we were on go version 1.17.2 so it was weird to see references to an older go version that wasn't pointing to the asdf install.

`pkg/services/mocks/SFTPClient.go:6:2: package io/fs is not in GOROOT (/usr/local/Cellar/go@1.14/1.14.7/libexec/src/io/fs)`

Upon further research I saw that my GOROOT was not being set to the asdf go location so I reshimed and updated my GOROOT with `asdf reshim golang && export GOROOT="$(asdf where golang)/go/"`

I am going to add GOROOT to my ~/.zshrc file going forward with the output from asdf as per instructions.