### PR TITLE
MB-10110 Better Happo documentation

### DIFF
--- a/docs/frontend/testing/frontend.md
+++ b/docs/frontend/testing/frontend.md
@@ -6,45 +6,6 @@ sidebar_position: 1
 
 ## Table of Contents
 
-<!-- toc -->
-
-* [Design + Engineering Process for new components](#design--engineering-process-for-new-components)
-  * [Design delivers component design](#design-delivers-component-design)
-  * [Engineering](#engineering)
-* [Testing](#testing)
-  * [Writing Tests](#writing-tests)
-  * [Unit Test Runners and Libraries](#unit-test-runners-and-libraries)
-  * [Browser Testing](#browser-testing)
-  * [Storybook Testing](#storybook-testing)
-* [Code Style](#code-style)
-  * [Auto-formatting](#auto-formatting)
-  * [Linting](#linting)
-  * [File Layout & Naming](#file-layout--naming)
-  * [Presentation vs. Container components](#presentation-vs-container-components)
-  * [Function Declarations](#function-declarations)
-  * [Ordering imports](#ordering-imports)
-  * [Using Redux](#using-redux)
-  * [Creating Forms](#creating-forms)
-  * [CSS Styling Standards](#css-styling-standards)
-    * [Using Sass and CSS Modules](#using-sass-and-css-modules)
-    * [Classnames](#classnames)
-    * [rem vs. em](#rem-vs-em)
-    * [BEM](#bem)
-    * [USWDS](#uswds)
-* [Tooling](#tooling)
-  * [Sublime Plugins](#sublime-plugins)
-  * [WebStorm](#webstorm)
-  * [VS Code](#vs-code)
-  * [vi](#vi)
-  * [Browser Extensions](#browser-extensions)
-* [Learning](#learning)
-  * [JavaScript Concepts](#javascript-concepts)
-  * [Resources](#resources)
-
-Regenerate with "pre-commit run -a markdown-toc"
-
-<!-- tocstop -->
-
 ## Design + Engineering Process for new components
 
 MilMove has defined a process for taking a new component from concept to design to implementation. This section of the doc will describe this process. We use [Storybook](https://storybook.js.org/) for showing the finished components and you can view all current ones on master by going to our [public storybook site](https://storybook.move.mil/). If you want to see things locally please check out the [How To Run Storybook](https://github.com/transcom/mymove/wiki/run-storybook) document.

--- a/docs/frontend/testing/frontend.md
+++ b/docs/frontend/testing/frontend.md
@@ -88,6 +88,13 @@ Historically we have leaned on Browser tests to cover testing our app thoroughly
 
 ### Storybook Testing
 
+:::info More Happo documentation
+There is [more information on Happo][docs-internal-happo] and how it's used in
+our Continuous Integration and Continuous Delivery tools section.
+
+[docs-internal-happo]: ../../tools/cicd/happo.md "More Happo documentation"
+:::
+
 * We use [Happo](https://happo.io/) for visually testing Storybook components.
 * Happo will run automatically as a required check on open PRs. If Happo catches any visual diffs with existing components, it will fail and require a review. Anyone at Truss _can_ view the report on Happo and approve or reject changes, but this action should be completed by the designer or PM reviewing the PR for acceptance. When someone accepts or rejects a report, their name and the result will be reported back to the Github PR status.
 * If changes have been approved, the PR can be merged and no further changes are needed.

--- a/docs/frontend/testing/frontend.md
+++ b/docs/frontend/testing/frontend.md
@@ -97,6 +97,20 @@ our Continuous Integration and Continuous Delivery tools section.
 
 * We use [Happo](https://happo.io/) for visually testing Storybook components.
 * Happo will run automatically as a required check on open PRs. If Happo catches any visual diffs with existing components, it will fail and require a review. Anyone at Truss _can_ view the report on Happo and approve or reject changes, but this action should be completed by the designer or PM reviewing the PR for acceptance. When someone accepts or rejects a report, their name and the result will be reported back to the Github PR status.
+
+:::caution Storybook Addon Knobs
+The current version of Storybook used by Happo does not support [the library
+`@storybook/addon-knobs`][npm-storybook-addon-knobs] as expected. While it may
+work locally, Happo will not properly render the contents of components that are
+configured using these **Knobs**.
+
+> 👀 Because of this, make sure that you are passing actual JavaScript Object
+> de-structuring when setting your objects for Storybook components rather than
+> the `object()` function provided by the `@storybook/addon-knobs` library
+
+[npm-storybook-addon-knobs]: https://www.npmjs.com/package/@storybook/addon-knobs
+:::
+
 * If changes have been approved, the PR can be merged and no further changes are needed.
 * If changes are rejected, the reviewer should specify what needs to be changed in a PR comment, and the engineer should address requested changes. Happo will run again on each code push.
 * You can also run Happo locally to preview the report before pushing changes up to a PR.

--- a/docs/frontend/testing/frontend.md
+++ b/docs/frontend/testing/frontend.md
@@ -102,9 +102,10 @@ The current version of Storybook used by Happo does not support [the library
 work locally, Happo will not properly render the contents of components that are
 configured using these **Knobs**.
 
-> 👀 Because of this, make sure that you are passing actual JavaScript Object
-> de-structuring when setting your objects for Storybook components rather than
-> the `object()` function provided by the `@storybook/addon-knobs` library
+```js title="Use de-structuring with plain JavaScript Objects rather than Knobs" {2}
+❌ displayInfo={object('displayInfo', ntsReleaseInfo)}
+✅ displayInfo={{ ...ntsReleaseInfo }}
+```
 
 [npm-storybook-addon-knobs]: https://www.npmjs.com/package/@storybook/addon-knobs
 :::

--- a/docs/frontend/testing/frontend.md
+++ b/docs/frontend/testing/frontend.md
@@ -4,8 +4,6 @@ sidebar_position: 1
 
 # Front-end / React Guide
 
-## Table of Contents
-
 ## Design + Engineering Process for new components
 
 MilMove has defined a process for taking a new component from concept to design to implementation. This section of the doc will describe this process. We use [Storybook](https://storybook.js.org/) for showing the finished components and you can view all current ones on master by going to our [public storybook site](https://storybook.move.mil/). If you want to see things locally please check out the [How To Run Storybook](https://github.com/transcom/mymove/wiki/run-storybook) document.

--- a/docs/tools/cicd/happo.md
+++ b/docs/tools/cicd/happo.md
@@ -1,4 +1,11 @@
-# Happo 
+# Happo
+
+:::info More Happo documentation
+There is [more information on Happo][docs-internal-happo] and how it's used in
+our Storybook Testing Frontend Testing section.
+
+[docs-internal-happo]: ../../frontend/testing/frontend.md "More Happo documentation"
+:::
 
 Happo is a UI diff checker tool that helps compare the UI pages from branches to master. When styling changes have been made, Happo notifies that a diff has occured and asks a reviewer to review the Happo changes before allowing the PR to be merged in.
 
@@ -8,7 +15,7 @@ When your CI/CD build has begun, you can view the status of the Happo under the 
 
 ![image](https://user-images.githubusercontent.com/84801109/141024060-32ff4825-b2b5-47e4-a281-682f6371a2d2.png)
 
-If the Happo check has failed, you must review the changes. You will see a list of diffs that will need to be reviewed/resolved before the Happo check can be approved. 
+If the Happo check has failed, you must review the changes. You will see a list of diffs that will need to be reviewed/resolved before the Happo check can be approved.
 
 For example, you may have changed title content like this:
 


### PR DESCRIPTION
While @mlm55, @YanZ777, and I were troubleshooting transcom/mymove#7840, we discovered that Knobs don't seem to be supported by Happo on the CI/CD side. So this documentation was updated to help folks not run into the issues that came up during that pairing session.

[=> pairing on Happo](https://ustcdp3.slack.com/archives/C029R9LDTD4/p1638901935175200) 🔒 
[=> the fix that is being referenced in this `caution` admonition](https://github.com/transcom/mymove/pull/7840/commits/4a9fd6bab5a1dcb3143ac7f7c19ecef6e4ca798a)