### PR TITLE
Update the homepage

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-MIT License
+Copyright 2021 U.S. Federal Government (in countries where recognized) and TrussWorks
 
-Copyright (c) 2021 United States Transportation Command
+MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/tutorial/intro.md
+++ b/docs/tutorial/intro.md
@@ -1,9 +1,16 @@
 ---
+title: Tutorial intro
 sidebar_position: 1
 slug: /tutorial/
 ---
 
-# Tutorial Intro
+:::warning
+This is Docusaurus documentation unrelated to MilMove, but can be found useful
+for understanding Docusaurus as a developer documentation portal. For the source
+of this documentation, see the Docusaurus documentation here.
+
+[💻 Docusaurus tutorial documentation on GitHub](https://github.com/facebook/docusaurus/tree/v2.0.0-beta.5/examples/classic/docs).
+:::
 
 Let's discover **Docusaurus in less than 5 minutes**. And here is an edit from GitHub.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -144,7 +144,7 @@ module.exports = {
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} United States Transportation Command. Built with Docusaurus.`,
+      copyright: `Copyright ${new Date().getFullYear()}  U.S. Federal Government (in countries where recognized) and TrussWorks. Built with Docusaurus.`
     },
     prism: {
       theme: lightCodeTheme,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -20,6 +20,9 @@ module.exports = {
   favicon: 'img/favicon.ico',
   organizationName: 'USTransCom',
   projectName: 'mymove-docs',
+  customFields: {
+    versionOfDocusaurus: '2.0.0-beta.5',
+  },
   themeConfig: {
     navbar: {
       title: 'MilMove Documentation',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -142,7 +142,7 @@ module.exports = {
             },
             {
               label: 'Docusaurus Official Docs',
-              href: 'https://docusaurus.io/',
+              href: 'https://6130eb5cde15830007fdf57b--docusaurus-2.netlify.app/docs',
             },
           ],
         },

--- a/src/components/HomepageFeatures.js
+++ b/src/components/HomepageFeatures.js
@@ -1,49 +1,70 @@
 import React from 'react';
 import clsx from 'clsx';
 import styles from './HomepageFeatures.module.css';
+import config from '../../docusaurus.config'
 
 const FeatureList = [
   {
-    title: 'Easy to Use',
-    Svg: require('../../static/img/undraw_docusaurus_mountain.svg').default,
+    title: 'Uses Markdown for documentation',
     description: (
       <>
-        Docusaurus was designed from the ground up to be easily installed and
-        used to get your website up and running quickly.
+        The MilMove Developer Portal uses Markdown for documentation which is
+        already widely used for other kinds of project documentation.
+      </>
+    ),
+    callout: (
+      <>
+        <a href="/mymove-docs/docs/tools/docusaurus/docusaurus"> Read about how
+        to contribute to this documentation in our Tools section.</a>
       </>
     ),
   },
   {
-    title: 'Focus on What Matters',
-    Svg: require('../../static/img/undraw_docusaurus_tree.svg').default,
+    title: 'Focused on developer experience',
     description: (
       <>
-        Docusaurus lets you focus on your docs, and we&apos;ll do the chores. Go
-        ahead and move your docs into the <code>docs</code> directory.
+        The MilMove Developer Portal lets contributors focus on documentation.
+        Docusaurus builds and manages the documentation while giving readers
+        the ability to search and integrate other data sources besides
+        Markdown.
+      </>
+    ),
+    callout: (
+      <>
+        <a href="https://github.com/transcom/mymove-docs/actions">
+          Checkout the GitHub Actions that power deployment and integrations
+          for the MilMove Developer Portal
+        </a>
       </>
     ),
   },
   {
-    title: 'Powered by React',
-    Svg: require('../../static/img/undraw_docusaurus_react.svg').default,
+    title: 'Powered by Docusaurus',
     description: (
       <>
-        Extend or customize your website layout by reusing React. Docusaurus can
-        be extended while reusing the same header and footer.
+        Extend or customize your the MilMove Developer Portal layout and
+        integrations by using React. Docusaurus can be extended while reusing
+        the same header and footer.
+      </>
+    ),
+    callout: (
+      <>
+        <a href="https://6130eb5cde15830007fdf57b--docusaurus-2.netlify.app/community/resources#community-plugins">
+          Here's a list of Community Plugins that work with Docusaurus
+          {config.customFields.versionOfDocusaurus}
+        </a>
       </>
     ),
   },
 ];
 
-function Feature({Svg, title, description}) {
+function Feature({title, description, callout}) {
   return (
     <div className={clsx('col col--4')}>
-      <div className="text--center">
-        <Svg className={styles.featureSvg} alt={title} />
-      </div>
       <div className="text--center padding-horiz--md">
         <h3>{title}</h3>
         <p>{description}</p>
+        <p>{callout}</p>
       </div>
     </div>
   );

--- a/src/components/HomepageFeatures.module.css
+++ b/src/components/HomepageFeatures.module.css
@@ -9,3 +9,7 @@
   height: 200px;
   width: 200px;
 }
+
+.features a {
+  text-decoration: underline;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,13 +6,13 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: rgb(33, 175, 144);
-  --ifm-color-primary-darker: rgb(31, 165, 136);
-  --ifm-color-primary-darkest: rgb(26, 136, 112);
-  --ifm-color-primary-light: rgb(70, 203, 174);
-  --ifm-color-primary-lighter: rgb(102, 212, 189);
-  --ifm-color-primary-lightest: rgb(146, 224, 208);
+  --ifm-color-primary: #5f779e;
+  --ifm-color-primary-dark: #556b8e;
+  --ifm-color-primary-darker: #4c5f7e;
+  --ifm-color-primary-darkest: #42536e;
+  --ifm-color-primary-light: #6e84a8;
+  --ifm-color-primary-lighter: #7e92b2;
+  --ifm-color-primary-lightest: #8e9fbb;
   --ifm-code-font-size: 95%;
 }
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,7 +16,7 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs">
+            to="/docs/about">
             Welcome to MilMove 🚚
           </Link>
         </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -30,7 +30,7 @@ export default function Home() {
   return (
     <Layout
       title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />">
+      description={`${siteConfig.title} - The OSS developer documentation for MyMove`}>
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
I updated the feature page to include some callouts. I consider this work part of migrating away from Docusaurus defaults and making this documentation **MilMove Developer Portal** more production ready.

<details>
<summary>📸  Old homepage screenshot</summary>

<img width="1943" alt="Captura de Pantalla 2022-01-25 a la(s) 1 19 33 p m" src="https://user-images.githubusercontent.com/706004/151035927-a22b7d2f-0d68-48f4-8687-dd8913028bf9.png">

</details>

<details>
<summary>📸  New homepage screenshot</summary>

<img width="1942" alt="Captura de Pantalla 2022-01-25 a la(s) 1 19 40 p m" src="https://user-images.githubusercontent.com/706004/151035982-15678c2e-2fea-4628-9931-64787c24b5c5.png">

</details>