### PR TITLE
Update nix setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,7 +2,7 @@
 if [ ! -r .nix-disable  ] && has nix-env; then
   # set NIX_PROFILE so nix-env operations don't need to manually
   # specify the profile path
-  export NIX_PROFILE=/nix/var/nix/profiles/mymove-docs
+  export NIX_PROFILE="/nix/var/nix/profiles/per-user/${LOGNAME}/mymove-docs"
 
   # Having NIX_SSL_CERT_FILE set means go won't use macOS keychain
   # based certs

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -6,18 +6,18 @@ in buildEnv {
   paths = [
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
-      name = "nodejs-14.17.1";
+      name = "nodejs-14.18.3";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "75916fb375eb571dceebef84263a6cb942372769";
+      rev = "847a715cfa7ed92cff06a780ec684e26388498e1";
     }) {}).nodejs-14_x
 
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
-      name = "yarn-1.22.10";
+      name = "yarn-1.22.17";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "559cf76fa3642106d9f23c9e845baf4d354be682";
+      rev = "c11d08f02390aab49e7c22e6d0ea9b176394d961";
     }) {}).yarn
   ];
 }

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -9,7 +9,7 @@ if [ ! -v NIX_PROFILE ]; then
 fi
 
 # make sure this is set, as we unset it for most projects
-export NIX_SSL_CERT_FILE=$HOME/.nix-profile/etc/ssl/certs/ca-bundle.crt
+#export NIX_SSL_CERT_FILE=$HOME/.nix-profile/etc/ssl/certs/ca-bundle.crt
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # install packages


### PR DESCRIPTION
The current nix configuration was failing on my M1 macbook. This PR updates the configuration to work for the latest version of nix and M1 setup.

Should be reviewed by someone using nix.

The following should pass and start docusaurus.

```sh
direnv allow
./nix/update.sh
yarn install
yarn start
```