### PR TITLE
[ MB-11574 ] Refactor the documentation around creating and understanding endpoints

### DIFF
--- a/docs/api/guides/guide-to-creating-an-endpoint.md
+++ b/docs/api/guides/guide-to-creating-an-endpoint.md
@@ -226,6 +226,13 @@ pkg/handlers/
 
 ### Anatomy of a handler
 
+:::warning
+> This message is a placeholder.
+
+This documentation is currently out of date while the proposed AppContext
+changes are made across all handlers
+:::
+
 All handlers should begin by storing the DB, logger, and/or session from the request into the [AppContext](use-stateless-services-with-app-context). This is the easiest way to get all three:
 
 ```go


### PR DESCRIPTION
> I am adding an admonition here that I'll probably remove. But since the
work for refactoring all the endpoints is split across various tickets,
we will need to handle the new and old way for the **Anatomy of a
handler** section here.

As mentioned above this work is tied to various Jira tickets around refactoring the Handlers to use the new `h.AuditableAppContextFromRequest` method instead of leveraging the `h.AppContextFromRequest` method. I think that this PR can be merged into the default branch independently of the other tickets, but I am tying it to the PR for transcom/mymove#8255 since that's the first ticket I'm working on in this context. 

Once all the other tickets related to the [Epic MB-11266](https://dp3.atlassian.net/browse/MB-11266)🔒 are complete, this documentation will need to be refactored to remove the old way of doing things since it will no longer exist in the codebase.

