### PR TITLE
Add ExcludeDeletedScope info and example to soft delete docs

### DIFF
--- a/docs/backend/guides/how-to/soft-delete.md
+++ b/docs/backend/guides/how-to/soft-delete.md
@@ -52,7 +52,7 @@ func FindDocumentsWithUploads(ctx context.Context, uploaderID uuid.UUID) {
 
 :::caution
 
-Unfortunately this will not filter any eager loaded associations so you may need to continue doing that depending on your query.
+Unfortunately this will not filter any eager loaded associations, you will still need to iterate through the results and filter them out or append them separately.
 
 ```go
 // This will not filter the eagerly loaded MTOShipments

--- a/docs/backend/guides/how-to/soft-delete.md
+++ b/docs/backend/guides/how-to/soft-delete.md
@@ -27,28 +27,28 @@ type ExampleModel struct {
 If this has not been done, one must [create a migration](migrate-the-database.md) to make these changes.
 
 ## Querying for non-deleted records
+
 Records that have been soft deleted will still exist in the database, so we must filter them out in our database queries if we want to omit deleted data.
 
-The Pop ORM has a chainable method called [Scope](https://gobuffalo.io/documentation/database/scoping/) that we can use to append the where clause(s) to only include non-deleted records.
+The Pop ORM has a chain-able method called [Scope](https://gobuffalo.io/documentation/database/scoping/) that we can use to append the where clause(s) to only include non-deleted records.
 
 ```go
 func FindShipment(ctx context.Context, shipmentID uuid.UUID) {
-	var shipments models.MTOShipments
-	ctx.DB().Scope(utilities.ExcludeDeletedScope()).All(&shipments)
+    var shipments models.MTOShipments
+    ctx.DB().Scope(utilities.ExcludeDeletedScope()).All(&shipments)
 }
 ```
 
-Sometimes you will need to qualify the deleted_at column with the model(s) that you care about to avoid an ambiguous column SQL error.  You can achieve this by passing in the models themsevles to the ExcludeDeletedScope method.  ExcludeDeletedScope will look up the proper table name of the model, using either reflection or the TableName() override specified in the model file.
+Sometimes you will need to qualify the deleted_at column with the model(s) that you care about to avoid an ambiguous column SQL error. You can achieve this by passing in the models themselves to the ExcludeDeletedScope method. ExcludeDeletedScope will look up the proper table name of the model, using either reflection or the TableName() override specified in the model file.
 
 ```go
 func FindDocumentsWithUploads(ctx context.Context, uploaderID uuid.UUID) {
-	var documents models.Documents
-	ctx.DB().Scope(utilities.ExcludeDeletedScope(models.Document{}, models.UserUpload{})).
-		Join("user_uploads", "user_uploads.document_id = documents.id").
-		All(&documents)
+    var documents models.Documents
+    ctx.DB().Scope(utilities.ExcludeDeletedScope(models.Document{}, models.UserUpload{})).
+        Join("user_uploads", "user_uploads.document_id = documents.id").
+        All(&documents)
 }
 ```
-
 
 :::caution
 
@@ -57,8 +57,8 @@ Unfortunately this will not filter any eager loaded associations so you may need
 ```go
 // This will not filter the eagerly loaded MTOShipments
 func FindMoveWithShipments(ctx context.Context, moveID uuid.UUID) {
-	var move models.Move
-	ctx.DB().Scope(utilities.ExcludeDeletedScope(models.MTOShipment{})).Eager(MTOShipments).Find(&move, moveID)
+    var move models.Move
+    ctx.DB().Scope(utilities.ExcludeDeletedScope(models.MTOShipment{})).Eager(MTOShipments).Find(&move, moveID)
 }
 ```
 
@@ -67,11 +67,11 @@ You should fall back to using a normal where clause if using an alias in your qu
 ```go
 // If a table is given an alias name then the scope may fail to work as intended
 func FindAllServiceMembersWithDocuments(ctx context.Context) {
-	var serviceMembers []models.ServiceMember
-	ctx.DB().Scope(utilities.ExcludeDeletedScope(models.Document{}, models.UserUpload{}).
-		Join("documents docs", "documents.service_member_id = service_members.id").
-		Join("user_uploads uu", "uu.document_id = docs.id").
-		All(&serviceMembers);
+    var serviceMembers []models.ServiceMember
+    ctx.DB().Scope(utilities.ExcludeDeletedScope(models.Document{}, models.UserUpload{}).
+        Join("documents docs", "documents.service_member_id = service_members.id").
+        Join("user_uploads uu", "uu.document_id = docs.id").
+        All(&serviceMembers);
 }
 ```
 

--- a/docs/backend/guides/how-to/soft-delete.md
+++ b/docs/backend/guides/how-to/soft-delete.md
@@ -68,7 +68,7 @@ You should fall back to using a normal where clause if using an alias in your qu
 // If a table is given an alias name then the scope may fail to work as intended
 func FindAllServiceMembersWithDocuments(ctx context.Context) {
 	var serviceMembers []models.ServiceMember
-	ctx.DB().Scope(utilities.ExcludeDeletedScope(models.Document{}, models.UserUpload).
+	ctx.DB().Scope(utilities.ExcludeDeletedScope(models.Document{}, models.UserUpload{}).
 		Join("documents docs", "documents.service_member_id = service_members.id").
 		Join("user_uploads uu", "uu.document_id = docs.id").
 		All(&serviceMembers);


### PR DESCRIPTION
Replaced the example query filtering out deleted records with a where clause to use the newer `Scope(utilities.ExcludeDeletedScope())` convenience call.

[Corresponding PR](https://github.com/transcom/mymove/pull/8445) that introduced the ExcludeDeletedScope

To test run:
1. `yarn install` && `yarn start`
2. Visit http://localhost:4000/mymove-docs/docs/backend/guides/how-to/soft-delete

![Screen Shot 2022-04-26 at 3 58 27 PM](https://user-images.githubusercontent.com/52669884/165382185-31636791-828c-40d9-801e-c2c63366aa04.png)