### PR TITLE
Update references section with correct links

### DIFF
--- a/docs/backend/testing/acceptance-testing-syncada-edi-invoicing.md
+++ b/docs/backend/testing/acceptance-testing-syncada-edi-invoicing.md
@@ -358,5 +358,5 @@ prime-api-client --insecure support-reviewed-payment-requests --filename payload
 
 Some helpful resources for getting this setup
 
-* [Acceptance Testing Payment Requests](Acceptance-Testing-Payment-Requests.md)
-* [Manually run Prime API for Slice demo](Manually-run-Prime-API-for-Slice-demo.md)
+* [Acceptance Testing Payment Requests](Acceptance-Testing-Payment-Requests)
+* [Manually run Prime API for Slice demo](Manually-run-Prime-API-for-Slice-demo)


### PR DESCRIPTION
Remove the `.md` since that was generating an invalid URL.