### PR TITLE
Add step to test-builds that saves build as an artifact

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -17,3 +17,9 @@ jobs:
 
       - name: Build Docusaurus from source
         run: yarn build
+
+      - name: Save build
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: docusaurus-build
+          path: build/


### PR DESCRIPTION
This might make it easier for people to review PRs. Once the workflow uploads the artifact, you can access it following the instructions here: https://docs.github.com/en/actions/managing-workflow-runs/downloading-workflow-artifacts