### PR TITLE
Make light theme oceanicNext

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,4 +1,4 @@
-const lightCodeTheme = require('prism-react-renderer/themes/github');
+const lightCodeTheme = require('prism-react-renderer/themes/oceanicNext');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
 // These Redirect lists for recently migated pages. These Redirects are here to


### PR DESCRIPTION
I chose to make the light theme a different dark theme because of the
colors we chose for our site and how highlighting lines in code blocks
seems to not work properly due to how the light themes render the dark
selection background.

I specifically chose oceanicNext due to the fact that it fits well with the
MilMove color scheme.
