### PR TITLE
Fix where the ADR files trigger CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/docs/about/adrs/* @transcom/truss-sr-eng
+/docs/adrs/* @transcom/truss-sr-eng


### PR DESCRIPTION
I missed this in #156. Sorry y'all.