### PR TITLE
[ MB-13238 ] Link to ECS docs in Confluence

### DIFF
--- a/docs/backend/guides/ghc/ghc-import-pricing-production.md
+++ b/docs/backend/guides/ghc/ghc-import-pricing-production.md
@@ -135,7 +135,9 @@ many steps a developer would do by hand, and if designed well, can allow a
 developer to spot check the results of the parser, run the task locally before
 data makes it into the Production environment.
 
-[How To Create a ECS Scheduled Task](https://github.com/transcom/mymove/blob/master/docs/how-to/create-an-ecs-scheduled-task.md#how-to-create-an-ecs-scheduled-task)
+:::info Interested in creating an ECS task from scratch?
+Read our Confluence documentation on [How To Create a ECS Scheduled Task](https://dp3.atlassian.net/l/cp/merdf22s).
+:::
 
 A scheduled task runs daily, and turns off if there are no actions to take.
 When the data changes (in our case for example, a new `xlsx` data set gets


### PR DESCRIPTION
# [Jira](https://dp3.atlassian.net/browse/MB-13238) ticket

When working on MB-13238, we had to setup an ECS task. It was difficult to find
the ECS documentation at first. After finding it, we realized there was a broken
link to this documentation. This patch fixes the issue.
