### PR TITLE
Removes a redirect for /docs/help

### DIFF
--- a/utils/redirect-backend.js
+++ b/utils/redirect-backend.js
@@ -306,12 +306,6 @@ module.exports = [
     ],
   },
   {
-    to: '/docs/backend/setup/common-errors-and-solutions',
-    from: [
-      '/docs/help/',
-    ],
-  },
-  {
     to: '/docs/backend/setup/backup-and-restore-dev-database',
     from: [
       '/docs/dev/contributing/database/Backup-and-Restore-Dev-Database',


### PR DESCRIPTION
This seems to be breaking this link: https://transcom.github.io/mymove-docs/docs/help/index by redirecting it else where.