### PR TITLE
[ MB-13351 ] Update the Redocusaurus internal documentation

### DIFF
--- a/docs/tools/docusaurus/redocusaurus.md
+++ b/docs/tools/docusaurus/redocusaurus.md
@@ -99,6 +99,14 @@ index 697ffef..30fdcc4 100644
          ],
 ```
 
+:::warning About the diff output above
+
+Due to edits to the `docusaurus.config.js` file since this documentation was
+written. The above diff is for illustrative purposes only and **will not apply
+cleanly to the `transcom/mymove` repository**.
+
+:::
+
 ### Viewing changes in local Docusaurus
 
 Now that you have updated the `docusaurus.config.js` with the changes mentioned

--- a/docs/tools/docusaurus/redocusaurus.md
+++ b/docs/tools/docusaurus/redocusaurus.md
@@ -16,9 +16,9 @@ diving into this documentation.
 
 This documentation leverages multiple projects that could lead to confusing
 error messages and warnings. For help, please reach out in
-[#wg-documentation][slack-wg-documentation]🔒 if you get stuck.
+[#c-documentation][slack-c-documentation]🔒 if you get stuck.
 
-[slack-wg-documentation]: https://ustcdp3.slack.com/archives/C027BDJ4678
+[slack-c-documentation]: https://ustcdp3.slack.com/archives/C027BDJ4678
 
 :::
 

--- a/docs/tools/docusaurus/redocusaurus.md
+++ b/docs/tools/docusaurus/redocusaurus.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Redocusaurus
 
-:::tip
+:::tip Why do I need to read this?
 
 This documentation is helpful for anyone editing documentation related to the
 Swagger API definitions. It is helpful to understand those concepts first before
@@ -12,7 +12,7 @@ diving into this documentation.
 
 :::
 
-:::caution
+:::info Need help? Ask in Slack.
 
 This documentation leverages multiple projects that could lead to confusing
 error messages and warnings. For help, please reach out in
@@ -41,7 +41,7 @@ documentation][doc-preset] on using presets for more general information.
 
 [doc-preset]: https://docusaurus.io/docs/presets
 
-:::info
+:::note How Docusaurus consumes Swagger documentation
 
 The way `transcom/mymove-docs` uses this is by leveraging the raw GitHub URLs
 for the Yaml files found in `transcom/mymove`. This means the API documentation

--- a/docs/tools/docusaurus/redocusaurus.md
+++ b/docs/tools/docusaurus/redocusaurus.md
@@ -48,7 +48,7 @@ for the Yaml files found in `transcom/mymove`. This means the API documentation
 is in sync with the default branch for the `transcom/mymove` repository. This
 means that until your Swagger file changes are merged into the default branch of
 `transcom/mymove` you cannot view the changes in the `transcom/mymove-docs`
-repository.
+repository neither locally nor on the published website.
 
 :::
 

--- a/docs/tools/docusaurus/redocusaurus.md
+++ b/docs/tools/docusaurus/redocusaurus.md
@@ -71,12 +71,12 @@ repository.
 ### Updating the Docusaurus configuration
 
 Once you have these repositories cloned locally, you will need to edit the
-`documentation.config.js` file to leverage the `spec:` property instead of the
-`specUrl` property.
+`documentation.config.js` file to have the local copy of compiled Swagger files
+rather than pointing to the raw GitHub URL for the default branch.
 
-The Git patch below shows what these changes would look like locally. The main
-thing to consider here is the location of the Swagger specification. In the
-example below, it is relative to the `transcom/mymove-docs` repository.
+The Git patch below shows what these changes would look like locally. The
+important thing to consider here is the location of the Swagger specification.
+In the example below, it is relative to the `transcom/mymove-docs` repository.
 
 ```diff title="Updates to specification paths" {9,10,14,15}
 diff --git a/docusaurus.config.js b/docusaurus.config.js
@@ -87,12 +87,12 @@ index 697ffef..30fdcc4 100644
        {
          specs: [
            {
--            specUrl: 'https://raw.githubusercontent.com/transcom/mymove/master/swagger/prime.yaml',
+-            spec: 'https://raw.githubusercontent.com/transcom/mymove/master/swagger/prime.yaml',
 +            spec: '../mymove/swagger/prime.yaml',
              routePath: '/api/prime',
            },
            {
--            specUrl: 'https://raw.githubusercontent.com/transcom/mymove/master/swagger/support.yaml',
+-            spec: 'https://raw.githubusercontent.com/transcom/mymove/master/swagger/support.yaml',
 +            spec: '../mymove/swagger/support.yaml',
              routePath: '/api/support',
            },


### PR DESCRIPTION
This patch series includes some minor house cleaning and some major changes to
how we use the plugin due to upgrades in the Redocusaurus plugin's
configuration. I discovered the need to update this stuff while reviewing work
for MB-13351 transcom/mymove#9118.

- [x] Add in some better headings to the admonitions
- [x] Update the help channel from `wg-` to `c-`
- [x] A little blurb how this affects viewing changes
- [x] Update viewing local changes example
  - The main reason why this patch series exists.
- [x] Warn folks that the diff output doesn't apply
