### PR TITLE
Add Cypress artifacts documentation

### DIFF
--- a/docs/backend/testing/run-e2e-tests.md
+++ b/docs/backend/testing/run-e2e-tests.md
@@ -68,3 +68,21 @@ SPECS=cypress/integration/office/**/* make e2e_test_docker
 ```sh
 yarn cypress run --spec cypress/integration/path/to/file.jsx
 ```
+
+## Automated tests artifacts from continuous integration
+
+:::note Artifacts overview call-out
+Please note that the Artifacts overview is the main area that's important to
+read.
+:::
+
+Currently we use CircleCI to store artifacts of failed Cypress tests. These are
+available to Trussels with access to the repository using the CircleCI UI.
+[Please see the official CirclCI documentation around storing build
+artifacts][docs-circleci-artifacts]. Artifacts are only stored on failed
+Integration Tests that run in CI. This is defined in our `.circleci/config.yml`
+file in the project under the `e2e_tests_cypress:` stanza. [Here's a link to an
+example][gh-circleci-e2e_tests_cypress].
+
+[docs-circleci-artifacts]: https://circleci.com/docs/artifacts#artifacts-overview
+[gh-circleci-e2e_tests_cypress]: https://github.com/transcom/mymove/blob/35630d2f7e94371393860dfd63f9b6d49eededdb/.circleci/config.yml#L567-L633

--- a/docs/backend/testing/run-e2e-tests.md
+++ b/docs/backend/testing/run-e2e-tests.md
@@ -74,7 +74,7 @@ yarn cypress run --spec cypress/integration/path/to/file.jsx
 :::note External documentation call-out
 The intention of this documentation is to not repeat the official docs. At the
 time of this writing, the documentation being referenced contains an _Artifacts
-overview_ section is the main area that shows where Artifacts are stored in the
+overview_ section, which shows where Artifacts are stored in the
 CircleCI UI.
 :::
 

--- a/docs/backend/testing/run-e2e-tests.md
+++ b/docs/backend/testing/run-e2e-tests.md
@@ -71,9 +71,11 @@ yarn cypress run --spec cypress/integration/path/to/file.jsx
 
 ## Automated tests artifacts from continuous integration
 
-:::note Artifacts overview call-out
-Please note that the Artifacts overview is the main area that's important to
-read.
+:::note External documentation call-out
+The intention of this documentation is to not repeat the official docs. At the
+time of this writing, the documentation being referenced contains an _Artifacts
+overview_ section is the main area that shows where Artifacts are stored in the
+CircleCI UI.
 :::
 
 Currently we use CircleCI to store artifacts of failed Cypress tests. These are

--- a/docs/backend/testing/run-e2e-tests.md
+++ b/docs/backend/testing/run-e2e-tests.md
@@ -78,13 +78,14 @@ overview_ section is the main area that shows where Artifacts are stored in the
 CircleCI UI.
 :::
 
-Currently we use CircleCI to store artifacts of failed Cypress tests. These are
-available to Trussels with access to the repository using the CircleCI UI.
-[Please see the official CirclCI documentation around storing build
-artifacts][docs-circleci-artifacts]. Artifacts are only stored on failed
-Integration Tests that run in CI. This is defined in our `.circleci/config.yml`
-file in the project under the `e2e_tests_cypress:` stanza. [Here's a link to an
-example][gh-circleci-e2e_tests_cypress].
+We use CircleCI to store artifacts for failed Cypress tests. These are available
+to all Trussels with GitHub repository access in the CircleCI UI. [Please see
+the official CirclCI documentation about build
+artifacts][docs-circleci-artifacts]. The project's Artifacts are only stored on
+failed Integration Tests that run in CI. This is defined in our
+`.circleci/config.yml` file in the project under the `e2e_tests_cypress:`
+stanza. [Here's a link to an example at the time of this
+writing][gh-circleci-e2e_tests_cypress].
 
 [docs-circleci-artifacts]: https://circleci.com/docs/artifacts#artifacts-overview
 [gh-circleci-e2e_tests_cypress]: https://github.com/transcom/mymove/blob/35630d2f7e94371393860dfd63f9b6d49eededdb/.circleci/config.yml#L567-L633


### PR DESCRIPTION
This work is tied to my volunteer work on the #c-documentation committee. The work is being tracked by @julieclennon in Confluence. This closed the AI around having short documentation on Cypress testing artifacts. 