### PR TITLE
Use frozen lockfile when installing dependencies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         run: npm install yarn
 
       - name: Install dependencies
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Build the Docusaurus app
         run: yarn build

--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -13,7 +13,7 @@ jobs:
         run: npm install yarn
 
       - name: Install dependencies
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Build Docusaurus from source
         run: yarn build


### PR DESCRIPTION
We should be using a frozen lockfile when installing dependencies for our CircleCI jobs. 
Using a frozen lockfile will help with detecting if a dependency has been added or removed without updating the lockfile since the job will fail if the correct dependencies are not installed.