### PR TITLE
Adding automation around ADR authoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,8 @@ Be aware that GitHub pages has a _soft_ limit of 10 deploys per hour, and it is 
 ## API Documentation
 
 [Please read more about how Redocusaurus is being used for API documentation.](https://transcom.github.io/mymove-docs/docs/dev/tools/redocusaurus)
+
+## ADR Documentation
+
+[Please read more about how ADRs are written in our ADR
+documentation.](https://transcom.github.io/mymove-docs/docs/guides/adrs/)

--- a/docs/guides/adrs/README.md
+++ b/docs/guides/adrs/README.md
@@ -8,6 +8,22 @@ read loosely as the more important words are decision records. To get started,
 take a look at [the ADR template](./template.md) and then copy it into
 `docs/adrs/` to make your own.
 
+## Creating ADRs using this repository
+
+For convenience, ADRs can be created using [the Template found in this
+guide](./template.md). You can also create a new ADR file automatically with
+`npm-run` scripts. Run the following command and set name to the dashed name of
+your ADR and the script will create an ADR file for you.
+
+```bash
+npm run new-adr --slug="my-short-and-brief-adr"
+```
+
+This command will create a new file for your ADR with placeholder title and
+description. Make sure you keep these values and the name of the file up to date
+as other ADRs may be added to the repository in the time it takes for your ADR
+to get peer-reviewed and approved.
+
 ## Required file names
 
 ADRs live in the `docs/adrs/` folder. They are automatically generated into

--- a/docs/guides/adrs/template.md
+++ b/docs/guides/adrs/template.md
@@ -1,5 +1,7 @@
 ---
 title: '📄 ADR Template'
+description: |
+    A plain-text description for the ADR that shows up on the ADR page.
 ---
 
 # *[short title of solved problem and solution]*

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve --port 4000",
+    "new-adr": "./scripts/new-adr.sh ${npm_config_slug}",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids"
   },

--- a/scripts/new-adr.sh
+++ b/scripts/new-adr.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+slug=$1
+
+if [ -z  "${npm_lifecycle_event}" ]
+then
+  echo "This script must be invoked by \`npm run new-adr\` and not run directly."
+  exit 1
+fi
+
+if [ -z "${slug}" ]
+then
+  echo "--slug'my-example-adr-name' needs to be passed in when running \`npm run new-adr\`"
+  exit 1
+fi
+
+num_prefix=$(printf '%04d' "$(find docs/adrs -iname '*.md' | wc -l)")
+
+new_adr_path="./docs/adrs/${num_prefix}-${slug}.md"
+
+cat << ADRHD > "${new_adr_path}"
+---
+title: '${num_prefix} A title for this ADR'
+description: |
+  A description for ADR ${num_prefix}
+---
+$(tail +4 ./docs/guides/adrs/template.md)
+ADRHD
+
+ls -fal "${new_adr_path}" && echo "File created successfully. Make sure you update the title and description as needed."

--- a/scripts/new-adr.sh
+++ b/scripts/new-adr.sh
@@ -20,13 +20,16 @@ num_prefix=$(printf '%04d' "$(find docs/adrs -iname '*.md' | wc -l)")
 
 new_adr_path="./docs/adrs/${num_prefix}-${slug}.md"
 
+# NOTE: The number after `tail` below with a `+` plus-sign prefix is the same
+# as the line number in the `docs/guides/adrs/template.md` file after the
+# frontmatter.
 cat << ADRHD > "${new_adr_path}"
 ---
 title: '${num_prefix} A title for this ADR'
 description: |
   A description for ADR ${num_prefix}
 ---
-$(tail +4 ./docs/guides/adrs/template.md)
+$(tail +6 ./docs/guides/adrs/template.md)
 ADRHD
 
 ls -fal "${new_adr_path}" && echo "File created successfully. Make sure you update the title and description as needed."


### PR DESCRIPTION
This patch adds support for running `npm run new-adr --slug="my-new-adr"` and
have it produce a new ADR file from the template with the suggested front-matter
from the documentation on the ADR guide page. This will help folks contributing
ADRs in the correct way without a whole lot of cognitive overhead.
