### PR TITLE
ADR for ejecting app from Create React App

### DIFF
--- a/docs/adrs/0077-eject-cra-app.md
+++ b/docs/adrs/0077-eject-cra-app.md
@@ -1,23 +1,66 @@
 ---
 title: '0077 Eject the application from Create React App'
 description: |
-  This ADR discusses options for ejecting the application from the Create React
-  App ecosystem. There are options here that can be done incrementally.
+  Decision outcome: To be decided
 ---
 
-# *[short title of solved problem and solution]*
+# Eject the Create React App configuration
 
-**User Story:** *[ticket/issue-number]* <!-- optional -->
+<!-- **User Story:** *[ticket/issue-number]* -->
 
-*[context and problem statement]*
-*[decision drivers | forces]* <!-- optional -->
+## Background
+
+In the previous [ADR 0072 Using React-App-Rewired][adr-0072], the decision of
+ejecting the React application was proposed as an alternative to leveraging
+_React-App-Rewired_. _React-App-Rewired_ has been lightly maintained since
+_Create-React-App_ version 2.0. It is also stated in the _React-App-Rewired_
+repository that with the use of the library, the configurations are now owned by
+the team that leverages the tool. In other words, the MilMove React application
+has technically been ejected since ADR 0072 has been implemented in the
+repository.
+
+[adr-0072]: ./0072-using-react-app-rewired.md
+
+The main reason to consider this again is that it was discovered on back on the
+13th of May 2022 that the _React-Scripts_, which _Create-React-App_ provides,
+does not call `compiler.close` which prevents the Webpack cache from being
+saved. This means that even without changes being made to the `src/` directory
+the `make client_build` command will always compile the application every time.
+This prevents the CI system from saving artifacts from previous builds and means
+that the CI system compiles the client code on every time regardless of changes
+made to that single component of the MilMove system.
+
+As pointed out in DP3 Slack 🔒, there's a significant speed up in Client
+compilation times in CI when the Webpack cache is enabled. According to
+Webpack's own documentation on this, the file system cache should be enabled for
+CI/CD systems.
+
+[🔒 DP3 Slack, discussing compile times of ~15 seconds](https://ustcdp3.slack.com/archives/CTQQJD3G8/p1672775265604429)
+
+[➡️  Webpack: Setup cache in CI/CD system](https://webpack.js.org/configuration/cache/#setup-cache-in-cicd-system)
+
+There is also evidence from the _Create-React-App_ repository that is has been
+only volunteer supported since the 6th of July 2021 according to one of the
+original co-authors of the library. This means that the future of
+_Create-React-App_ is certainly unknown for our project. Since,
+_Create-React-App_ is only a set of useful configurations for working with a
+React application, we are again presented with evidence that we should manage
+the configuration for our MilMove React application ourselves.
+
+[ ➡️  _Create-React-App_ does not have a regular maintainer](https://github.com/facebook/create-react-app/issues/11180#issuecomment-874748552)
+
+## Decision drivers
+
+There are a number of decision drivers here to determine how we consider how to
+approach this work. The first driver is the fact that we've been using
+_React-App-Rewired_ now for seven months with a lot of success. This means that
+we've been effectively _owning our configuration files_ as it was stated in the
+_React-App-Rewired_ repository. The second driver is that we are noticing
 
 ## Considered Alternatives
 
-* *[alternative 1]*
-* *[alternative 2]*
-* *[alternative 3]*
-* *[...]* <!-- numbers of alternatives can vary -->
+* *Do nothing, keep using React-App-Rewired to dynamically patch configurations*
+* *Eject the __Create-React-App__ configuration*
 
 ## Decision Outcome
 

--- a/docs/adrs/0077-eject-cra-app.md
+++ b/docs/adrs/0077-eject-cra-app.md
@@ -72,24 +72,32 @@ This ADR has not been decided on yet. Once it has been reviewed by the MilMove
 engineer practice, it will have a decision outcome written in this section.
 :::
 
+## Pros and Cons of the Alternatives
 
-### *[alternative 1]*
+### *Do nothing, keep using React-App-Rewired to dynamically patch configurations*
 
-* `+` *[argument 1 pro]*
-* `+` *[argument 2 pro]*
-* `-` *[argument 1 con]*
-* *[...]* <!-- numbers of pros and cons can vary -->
+* `+` *Our 0072 ADR covers situations where we can dynamically patch
+  configurations*
+* `+` *We continue benefiting from minor _Create-React-App_ updates, __if they
+  occur__*
+* `-` *We remain in the _Create-React-App_ ecosystem for longer than recommended
+  by the co-author.*
 
-### *[alternative 2]*
+### *Eject the __Create-React-App__ configuration*
 
-* `+` *[argument 1 pro]*
-* `+` *[argument 2 pro]*
-* `-` *[argument 1 con]*
-* *[...]* <!-- numbers of pros and cons can vary -->
-
-### *[alternative 3]*
-
-* `+` *[argument 1 pro]*
-* `+` *[argument 2 pro]*
-* `-` *[argument 1 con]*
-* *[...]* <!-- numbers of pros and cons can vary -->
+* `+` *Reduces the dependency on **Create-React-App**.*
+* `+` *Allows engineering team to take ownership of the configuration for the
+  client application.*
+* `-` *No wide-support from engineering team to maintain the build toolchain.*
+  * `+` Without wide-support from engineering, the lack of configuration is a safer
+  space to exist in for the project regardless of the benefits or
+  responsibilities to leverage the build toolchain manually.
+* `+` *Removes the reliance on **Create-React-App** and **React-Scripts** to
+  incorporate security fixes which do not have much larger teams dedicated to
+  this.*
+* `+` *Breaks out of the update cycle for **Create-React-App** and
+  **React-Scripts**.*
+  * `-` The update cycle of **Create-React-App** and **React-Scripts** is one that
+  is owned by their upstream development team. This cycle is a benefit to the
+  MilMove engineering team as there are less dependencies that need to be
+  managed by us.

--- a/docs/adrs/0077-eject-cra-app.md
+++ b/docs/adrs/0077-eject-cra-app.md
@@ -67,11 +67,11 @@ _React-App-Rewired_ repository. The second driver is that we are noticing
 
 ## Decision Outcome
 
-* Chosen Alternative: *[alternative 1]*
-* *[justification. e.g., only alternative, which meets KO criterion decision driver | which resolves force | ... | comes out best (see below)]*
-* *[consequences. e.g., negative impact on quality attribute, follow-up decisions required, ...]* <!-- optional -->
+:::info
+This ADR has not been decided on yet. Once it has been reviewed by the MilMove
+engineer practice, it will have a decision outcome written in this section.
+:::
 
-## Pros and Cons of the Alternatives <!-- optional -->
 
 ### *[alternative 1]*
 

--- a/docs/adrs/0077-eject-cra-app.md
+++ b/docs/adrs/0077-eject-cra-app.md
@@ -26,7 +26,7 @@ The main reason to consider this again is that it was discovered on back on the
 does not call `compiler.close` which prevents the *webpack* cache from being
 saved. This means that the `make client_build` command will always compile the
 application every time, even without changes being made to the `src/` directory.
-This prevents the CI system from saving artifacts from previous builds and means
+Not having the *webpack* cache being saved prevents the CI system from saving artifacts from previous builds and means
 that the CI system compiles the client code on every time regardless of changes
 made to that single component of the MilMove system.
 

--- a/docs/adrs/0077-eject-cra-app.md
+++ b/docs/adrs/0077-eject-cra-app.md
@@ -58,7 +58,12 @@ There are a number of decision drivers here to determine how we consider how to
 approach this work. The first driver is the fact that we've been using
 _React-App-Rewired_ now for seven months with a lot of success. This means that
 we've been effectively _owning our configuration files_ as it was stated in the
-_React-App-Rewired_ repository. The second driver is that we are noticing
+_React-App-Rewired_ repository. The second driver is that we are noticing there
+are some production optimizations that our MilMove team would like to do to our
+building of the client code in CI.
+
+These two drivers may be enough to help the MilMove engineering team make a
+decision here.
 
 ## Considered Alternatives
 

--- a/docs/adrs/0077-eject-cra-app.md
+++ b/docs/adrs/0077-eject-cra-app.md
@@ -14,7 +14,7 @@ In the previous [ADR 0072 Using React-App-Rewired][adr-0072], the decision of
 ejecting the React application was proposed as an alternative to leveraging
 _React-App-Rewired_. _React-App-Rewired_ has been lightly maintained since
 _Create-React-App_ version 2.0. It is also stated in the _React-App-Rewired_
-repository that with the use of the library, the configurations are now owned by
+repository that with the use of the library the configurations are now owned by
 the team that leverages the tool. In other words, the MilMove React application
 has technically been ejected since ADR 0072 has been implemented in the
 repository.
@@ -23,7 +23,7 @@ repository.
 
 The main reason to consider this again is that it was discovered on back on the
 13th of May 2022 that the _React-Scripts_, which _Create-React-App_ provides,
-does not call `compiler.close` which prevents the Webpack cache from being
+does not call `compiler.close` which prevents the *webpack* cache from being
 saved. This means that even without changes being made to the `src/` directory
 the `make client_build` command will always compile the application every time.
 This prevents the CI system from saving artifacts from previous builds and means
@@ -31,23 +31,26 @@ that the CI system compiles the client code on every time regardless of changes
 made to that single component of the MilMove system.
 
 As pointed out in DP3 Slack 🔒, there's a significant speed up in Client
-compilation times in CI when the Webpack cache is enabled. According to
-Webpack's own documentation on this, the file system cache should be enabled for
-CI/CD systems.
+compilation times in CI when the *webpack* cache is enabled. According to
+*webpack*'s own documentation on this, the file system cache should be enabled
+for CI/CD systems.
 
-[🔒 DP3 Slack, discussing compile times of ~15 seconds](https://ustcdp3.slack.com/archives/CTQQJD3G8/p1672775265604429)
+[🔒 DP3 Slack, discussing compile times of ~15 seconds when there are no Client app changes.](https://ustcdp3.slack.com/archives/CTQQJD3G8/p1672775265604429)
 
-[➡️  Webpack: Setup cache in CI/CD system](https://webpack.js.org/configuration/cache/#setup-cache-in-cicd-system)
+[➡️  *webpack*: Setup cache in CI/CD system](https://webpack.js.org/configuration/cache/#setup-cache-in-cicd-system)
 
 There is also evidence from the _Create-React-App_ repository that is has been
-only volunteer supported since the 6th of July 2021 according to one of the
-original co-authors of the library. This means that the future of
-_Create-React-App_ is certainly unknown for our project. Since,
-_Create-React-App_ is only a set of useful configurations for working with a
-React application, we are again presented with evidence that we should manage
-the configuration for our MilMove React application ourselves.
+volunteer-supported since the 6th of July 2021 according to one of the original
+co-authors of the library. This means that the future of _Create-React-App_ is
+unknown for our project. Since, _Create-React-App_ is only a set of useful
+configurations for working with a React application, we are again presented with
+evidence that we should manage the configuration for our MilMove React
+application ourselves. The original co-creator even states that it might not be
+the best tool to get started with React apps today nor does it have a regular
+maintainer. _Create-React-App_ is not considered the best tool for production
+React apps since the co-authors message.
 
-[ ➡️  _Create-React-App_ does not have a regular maintainer](https://github.com/facebook/create-react-app/issues/11180#issuecomment-874748552)
+[ ➡️  _Create-React-App_: Message from Dan A. co-author](https://github.com/facebook/create-react-app/issues/11180#issuecomment-874748552)
 
 ## Decision drivers
 

--- a/docs/adrs/0077-eject-cra-app.md
+++ b/docs/adrs/0077-eject-cra-app.md
@@ -21,8 +21,8 @@ repository.
 
 [adr-0072]: ./0072-using-react-app-rewired.md
 
-The main reason to consider this again is that it was discovered on back on the
-13th of May 2022 that the _React-Scripts_, which _Create-React-App_ provides,
+The main reason to consider this again is that on May 13, 2022 it was discovered  
+that the _React-Scripts_, which _Create-React-App_ provides,
 does not call `compiler.close` which prevents the *webpack* cache from being
 saved. This means that the `make client_build` command will always compile the
 application every time, even without changes being made to the `src/` directory.

--- a/docs/adrs/0077-eject-cra-app.md
+++ b/docs/adrs/0077-eject-cra-app.md
@@ -1,0 +1,49 @@
+---
+title: '0077 Eject the application from Create React App'
+description: |
+  This ADR discusses options for ejecting the application from the Create React
+  App ecosystem. There are options here that can be done incrementally.
+---
+
+# *[short title of solved problem and solution]*
+
+**User Story:** *[ticket/issue-number]* <!-- optional -->
+
+*[context and problem statement]*
+*[decision drivers | forces]* <!-- optional -->
+
+## Considered Alternatives
+
+* *[alternative 1]*
+* *[alternative 2]*
+* *[alternative 3]*
+* *[...]* <!-- numbers of alternatives can vary -->
+
+## Decision Outcome
+
+* Chosen Alternative: *[alternative 1]*
+* *[justification. e.g., only alternative, which meets KO criterion decision driver | which resolves force | ... | comes out best (see below)]*
+* *[consequences. e.g., negative impact on quality attribute, follow-up decisions required, ...]* <!-- optional -->
+
+## Pros and Cons of the Alternatives <!-- optional -->
+
+### *[alternative 1]*
+
+* `+` *[argument 1 pro]*
+* `+` *[argument 2 pro]*
+* `-` *[argument 1 con]*
+* *[...]* <!-- numbers of pros and cons can vary -->
+
+### *[alternative 2]*
+
+* `+` *[argument 1 pro]*
+* `+` *[argument 2 pro]*
+* `-` *[argument 1 con]*
+* *[...]* <!-- numbers of pros and cons can vary -->
+
+### *[alternative 3]*
+
+* `+` *[argument 1 pro]*
+* `+` *[argument 2 pro]*
+* `-` *[argument 1 con]*
+* *[...]* <!-- numbers of pros and cons can vary -->

--- a/docs/adrs/0077-eject-cra-app.md
+++ b/docs/adrs/0077-eject-cra-app.md
@@ -24,8 +24,8 @@ repository.
 The main reason to consider this again is that it was discovered on back on the
 13th of May 2022 that the _React-Scripts_, which _Create-React-App_ provides,
 does not call `compiler.close` which prevents the *webpack* cache from being
-saved. This means that even without changes being made to the `src/` directory
-the `make client_build` command will always compile the application every time.
+saved. This means that the `make client_build` command will always compile the
+application every time, even without changes being made to the `src/` directory.
 This prevents the CI system from saving artifacts from previous builds and means
 that the CI system compiles the client code on every time regardless of changes
 made to that single component of the MilMove system.

--- a/docs/adrs/0077-eject-cra-app.md
+++ b/docs/adrs/0077-eject-cra-app.md
@@ -39,10 +39,10 @@ for CI/CD systems.
 
 [➡️  *webpack*: Setup cache in CI/CD system](https://webpack.js.org/configuration/cache/#setup-cache-in-cicd-system)
 
-There is also evidence from the _Create-React-App_ repository that is has been
-volunteer-supported since the 6th of July 2021 according to one of the original
-co-authors of the library. This means that the future of _Create-React-App_ is
-unknown for our project. Since, _Create-React-App_ is only a set of useful
+According to one of the original co-authors of the library, the _Create-React-App_ 
+repository has been volunteer-supported since the 6th of July 2021. This means that 
+the future of _Create-React-App_ is unknown for our project. 
+Since _Create-React-App_ is only a set of useful
 configurations for working with a React application, we are again presented with
 evidence that we should manage the configuration for our MilMove React
 application ourselves. The original co-creator even states that it might not be


### PR DESCRIPTION
This was started from the proof of concept in these two different PRs.

- transcom/mymove#9825
- transcom/mymove#9812

The idea behind this ADR is to focus on speeding up the client build for the
React application. This has been discussed a few times in 2022 and is being
revisited in 2023. 

More information to come to this description soon ...
