### PR TITLE
MB-14922 reorganize readme project layout

### DIFF
--- a/docs/about/Welcome.md
+++ b/docs/about/Welcome.md
@@ -29,27 +29,6 @@ routed to your `name@truss.works` email automatically. Don't use this for the
 office-side of account creation. It's helpful to use these types of accounts for
 the customer-side accounts.
 
-## Project Layout
-
-All of our code is intermingled in the top level directory of `mymove`. Here is an explanation of what some of these
-directories contain:
-
-- `.circleci`: Directory for CircleCI CI/CD configuration
-- `bin`: A location for tools compiled from the `cmd` directory
-- `build`: The build output directory for the client. This is what the development server serves
-- `cmd`: The location of main packages for any go binaries we build
-- `config`: Config files for the database and AWS ECS. Also certificates.
-- `cypress`: The integration test files for the [Cypress tool](https://www.cypress.io/)
-- `docs`: A location for docs for the project. This is where ADRs are
-- `internal`: Generated code for duty station loader
-- `migrations`: Database migrations, see [./migrations/README.md]
-- `node_modules`: Cached javascript dependencies for the client
-- `pkg`: The location of all of our go code for the server and various tools
-- `public`: The client's static resources
-- `scripts`: A location for tools helpful for developing this project
-- `src`: The react source code for the client
-- `swagger`: The swagger definition files for each of our APIs
-
 ## Application Setup
 
 Note: These instructions are a living document and often fall out-of-date.

--- a/docs/about/project-layout.md
+++ b/docs/about/project-layout.md
@@ -1,0 +1,20 @@
+# Project Layout
+
+All of our code is intermingled in the top level directory of `mymove`. Here is an explanation of what some of these
+directories contain:
+
+- `.circleci`: Directory for CircleCI CI/CD configuration
+- `bin`: A location for tools compiled from the `cmd` directory
+- `build`: The build output directory for the client. This is what the development server serves
+- `cmd`: The location of main packages for any go binaries we build
+- `config`: Config files for the database and AWS ECS. Also certificates.
+- `cypress`: The integration test files for the [Cypress tool](https://www.cypress.io/)
+- `docs`: A location for docs for the project. This is where ADRs are
+- `internal`: Generated code for duty station loader
+- `migrations`: Database migrations, see [./migrations/README.md]
+- `node_modules`: Cached javascript dependencies for the client
+- `pkg`: The location of all of our go code for the server and various tools
+- `public`: The client's static resources
+- `scripts`: A location for tools helpful for developing this project
+- `src`: The react source code for the client
+- `swagger`: The swagger definition files for each of our APIs


### PR DESCRIPTION
Jira ticket [MB-14922](https://dp3.atlassian.net/browse/MB-14922)

This part of ongoing work to reorganize the `Welcome.md` page into more manageable chunks.
The PR pulls out the Project Layout section into its own page.

## Specific review questions 
I'm debating on putting this back into the mymove repo wiki to keep it as close to the code as possible. What do you all think?

[MB-14922]: https://dp3.atlassian.net/browse/MB-14922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ