### PR TITLE
MB-14922 Remove extra bracket

### DIFF
--- a/docs/about/Home.md
+++ b/docs/about/Home.md
@@ -3,6 +3,7 @@ id: index
 slug: /about/
 sidebar_position: 1
 ---
+
 # Welcome to the MilMove Wiki!
 
 The intention for this wiki is to share our collective knowledge on best practices and allow everyone working on the DoD MilMove project to write code in compatible styles.
@@ -17,7 +18,7 @@ If you are looking to understand choices made in this project, see the list of
 :::tip Editing Docusaurus
 
 If you are looking to edit or add to this documentation, checkout the page on
-[Using Docusaurus](../tools/docusaurus/docusaurus.md)].
+[Using Docusaurus](../tools/docusaurus/docusaurus.md).
 
 :::
 


### PR DESCRIPTION
There's a extra bracket that's a typo. This PR removes it.
The auto formatter also decided it wanted to add an extra line between the front matter and the header.