### PR TITLE
MB-15044 Add documentation for the GitHub Action Front End Linter

### DIFF
--- a/docs/tools/cicd/github_actions/front-end-linter.md
+++ b/docs/tools/cicd/github_actions/front-end-linter.md
@@ -1,0 +1,14 @@
+# Front End Linter
+
+## Configuration
+
+The front end linters are configured to run based off of [`front-end-linter.yml`](https://github.com/transcom/mymove/blob/main/.github/workflows/front-end-linter.yml). Those linters are configured inside of [`.eslint.rc`](https://github.com/transcom/mymove/blob/main/.eslintrc.js) and [`.eslintignore`](https://github.com/transcom/mymove/blob/main/.eslintignore).
+
+## Purpose
+
+This GitHub Action checks the frontend code to assure that it is adhering to the rules outlined inside of `.eslintrc.js`. These rules help flag possible bugs and stylistic errors.
+
+## Additional Notes
+
+While most of the rules are pulled from other packages, a few rules are custom written. Most notable of these is the [`ato/no-unapproved-annotation`](https://github.com/transcom/mymove/blob/main/eslint-plugin-ato/no-unapproved-annotation.js) rule, which relates to the static analysis workflow.
+Further information on static analysis can be found in our [Guides to Static Analysis](https://dp3.atlassian.net/wiki/spaces/MT/pages/1921384494/Static+Analysis)


### PR DESCRIPTION
[MB-15044](https://dp3.atlassian.net/browse/MB-15044)

Add documentation for the purpose and configuration of the front end linter.

[MB-15044]: https://dp3.atlassian.net/browse/MB-15044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ