### PR TITLE
MB-15044 Add documentation for the GitHub Action Auto Approve

### DIFF
--- a/docs/tools/cicd/github_actions/auto-approve.md
+++ b/docs/tools/cicd/github_actions/auto-approve.md
@@ -1,0 +1,9 @@
+# Auto Approve
+
+## Configuration
+
+[`auto-approve.yml`](https://github.com/transcom/mymove/blob/main/.github/workflows/auto-approve.yml)
+
+## Purpose
+
+The GitHub Action auto approve automatically approves pull requests. This GitHub Action only approves pull requests whose author is the Dependabot and that has the dependencies label.


### PR DESCRIPTION
[MB-15044](https://dp3.atlassian.net/browse/MB-15044)

Add documentation for the GitHub Action auto approve.

[MB-15044]: https://dp3.atlassian.net/browse/MB-15044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ