### PR TITLE
[ MB-15044 ] Add GitHub code blocks to the documentation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -182,6 +182,7 @@ module.exports = {
     ],
   ],
   themes: [
+    '@saucelabs/theme-github-codeblock',
     [
       require.resolve("@easyops-cn/docusaurus-search-local"),
       /** @type {import("@easyops-cn/docusaurus-search-local").PluginOptions} */

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@docusaurus/plugin-client-redirects": "2.2.0",
     "@docusaurus/preset-classic": "2.2.0",
     "@easyops-cn/docusaurus-search-local": "^0.33.6",
+    "@saucelabs/theme-github-codeblock": "0.1.1",
     "clsx": "^1.2.1",
     "eslint": "^8.31.0",
     "eslint-config-prettier": "^8.6.0",
@@ -30,6 +31,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "redocusaurus": "^1.4.0",
+    "url": "0.11.0",
     "url-loader": "^4.1.1"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,6 +1974,11 @@
     pluralize "^8.0.0"
     yaml-ast-parser "0.0.43"
 
+"@saucelabs/theme-github-codeblock@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@saucelabs/theme-github-codeblock/-/theme-github-codeblock-0.1.1.tgz#d2caa3fbf56c38ae2fe974871f1188226bb57d92"
+  integrity sha512-iHzODYjcUAYI4eJzLrNCw/Iq9SWxCKB/cMgEKHjRmNMb2NKch1dsI2ZSCg8lNedIPmOaRfqHT29hLyMoc/5Wpg==
+
 "@sideway/address@^4.1.3":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"
@@ -6952,6 +6957,11 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==
+
 punycode@^1.3.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -6980,6 +6990,11 @@ qs@6.11.0:
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
   dependencies:
     side-channel "^1.0.4"
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -8475,6 +8490,14 @@ url-template@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
   integrity sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==
+
+url@0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  integrity sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
 
 use-composed-ref@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
- [x] Adding the GitHub Codeblock theme plugin;

Feeling inspired by @yanz777's great work on MB-15044, I found that Docusaurus
has a plugin that brings in the code from a public GitHub repository into
Docusaurus as fenced codeblock. This seems particularly helpful for the intended
reader of this kind of documentation.

Here's an example of how #277 would need to be changed to use this new
codeblock. 

```diff
diff --git a/docs/tools/cicd/github_actions/auto-approve.md b/docs/tools/cicd/github_actions/auto-approve.md
index 6da7e7f6d..d951e35f0 100644
--- a/docs/tools/cicd/github_actions/auto-approve.md
+++ b/docs/tools/cicd/github_actions/auto-approve.md
@@ -2,7 +2,15 @@
 
 ## Configuration
 
+<!--
+The following link is commented to out, but can be used if the codeblock below
+fails to render for whatever reason.
 [`auto-approve.yml`](https://github.com/transcom/mymove/blob/main/.github/workflows/auto-approve.yml)
+-->
+
+```yml reference
+https://github.com/transcom/mymove/blob/main/.github/workflows/auto-approve.yml
+```
 
 ## Purpose
 
```

And here's an image preview of the code changes from above.

<img width="1734" alt="Captura de pantalla 2023-01-26 a la(s) 8 26 20 a m" src="https://user-images.githubusercontent.com/706004/214854015-2ac8dafd-3000-46c0-88f8-7c99218614e5.png">


This branch does not need to be merged in before all the other work. We can
update the other branches after this makes it into the default branch as a nice
to have feature addition to the work in MB-15044.

[➡️  Link to Jira Ticket 🔒](https://dp3.atlassian.net/browse/MB-15044)
