### PR TITLE
MB-15044 Use Code Block for the Auto Approve Documentation

### DIFF
--- a/docs/tools/cicd/github_actions/auto-approve.md
+++ b/docs/tools/cicd/github_actions/auto-approve.md
@@ -2,7 +2,9 @@
 
 ## Configuration
 
-[`auto-approve.yml`](https://github.com/transcom/mymove/blob/main/.github/workflows/auto-approve.yml)
+```yml reference
+https://github.com/transcom/mymove/blob/main/.github/workflows/auto-approve.yml
+```
 
 ## Purpose
 


### PR DESCRIPTION
[MB-15044](https://dp3.atlassian.net/browse/MB-15044)

feat: Use code block instead of linking to the code for the auto approve documentation

[MB-15044]: https://dp3.atlassian.net/browse/MB-15044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ