### PR TITLE
MB-15044 Add documentation for the GitHub Action go auto approve

### DIFF
--- a/docs/tools/cicd/github_actions/go-auto-approve.md
+++ b/docs/tools/cicd/github_actions/go-auto-approve.md
@@ -1,0 +1,11 @@
+# Go Auto Approve
+
+## Configuration
+
+```yml reference
+https://github.com/transcom/mymove/blob/main/.github/workflows/go-auto-approve.yml
+```
+
+## Purpose
+
+The Go Auto Approve GitHub Action runs on pull requests created by Dependabot and that have the dependencies label. This action is used to ensure that our Go dependencies are kept in alignment within our `go.mod` and `go.sum` files.


### PR DESCRIPTION
[MB-15044](https://dp3.atlassian.net/browse/MB-15044)

feat: Add documentation for the GitHub Action go auto approve

[MB-15044]: https://dp3.atlassian.net/browse/MB-15044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ