### PR TITLE
MB-15044 Documentation for deploy app client tls

### DIFF
--- a/docs/tools/cicd/circleci/deploy-app-client-tls.md
+++ b/docs/tools/cicd/circleci/deploy-app-client-tls.md
@@ -1,0 +1,11 @@
+# Deploy App Client TLS
+
+## Configuration
+
+```yaml reference
+https://github.com/transcom/mymove/blob/7914158b070c8a733cc94a8cf3e4c4747855ea26/.circleci/config.yml#L1747-L1765
+```
+
+## Extra Notes
+
+The `deploy-app-client-tls-steps` does two separate commit checks at different times. The first check occurs before anything is deployed to AWS and makes use of `scripts/compare-deployed-commit`. The second check happens after the deploy and uses `scripts/check-deployed-commit`. Both scripts make use of our tls certificates.


### PR DESCRIPTION
[MB-15044](https://dp3.atlassian.net/browse/MB-15044)

feat: Add additional context around the deploy-app-client-tls job.

Adding this documentation was partially driven by our mishaps with updating certificates troubleshooting. This document aims to provide additional context that would be useful, if a similar mishap occurs again. 

[MB-15044]: https://dp3.atlassian.net/browse/MB-15044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ