### PR TITLE
Enable a hideable sidebar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -21,6 +21,11 @@ module.exports = {
   organizationName: 'USTransCom',
   projectName: 'mymove-docs',
   themeConfig: {
+    docs: {
+      sidebar: {
+        hideable: true,
+      },
+    },
     navbar: {
       title: 'MilMove Documentation',
       logo: {


### PR DESCRIPTION
The documentation says this is helpful when wanting the reader to focus
on the documentation. I like it because I have vertical monitors and
appreciate the option to hide the sidebar so I can better read the
content. It also works well to read the documentation on a tablet as
well.
