### PR TITLE
[MB-15308] Consolidate pre-commit troubleshooting issues onto the troubleshooting page

### DIFF
--- a/docs/about/application-setup/dependencies/pre-commit.md
+++ b/docs/about/application-setup/dependencies/pre-commit.md
@@ -38,4 +38,4 @@ make server_generate client_deps && pre-commit run -a
 
 ## Troubleshooting pre-commit issues
 
-[Troubleshoot Precommit Hook Failures](../../../guides/troubleshoot-precommit-hook-failures.md)
+[Troubleshoot Precommit Hook Failures](/docs/backend/guides/troubleshoot-precommit-hook-failures.md)

--- a/docs/about/application-setup/dependencies/pre-commit.md
+++ b/docs/about/application-setup/dependencies/pre-commit.md
@@ -36,27 +36,6 @@ or
 make server_generate client_deps && pre-commit run -a
 ```
 
-## Pre-Commit Troubleshooting (Manual): Process hanging on install hooks
+## Troubleshooting pre-commit issues
 
-If any pre-commit commands (or `make deps`) result in hanging or incomplete
-installation, remove the pre-commit cache and the `.client_deps.stamp` and try again:
-
-```shell
-rm -rf ~/.cache/pre-commit
-rm .client_deps.stamp
-```
-
-## Pre-Commit Troubleshooting (Nix): SSL: CERTIFICATE VERIFY FAILED
-
-This can happen because of the way certs need to be handled in this project and `nix`. To get around this issue, you
-can try running:
-
-```shell
-NIX_SSL_CERT_FILE=$HOME/.nix-profile/etc/ssl/certs/ca-bundle.crt <pre-commit related command>
-```
-
-E.g.
-
-```shell
-NIX_SSL_CERT_FILE=$HOME/.nix-profile/etc/ssl/certs/ca-bundle.crt pre-commit install-hooks
-```
+[Troubleshoot Precommit Hook Failures](../../../guides/troubleshoot-precommit-hook-failures.md)

--- a/docs/backend/guides/troubleshoot-precommit-hook-failures.md
+++ b/docs/backend/guides/troubleshoot-precommit-hook-failures.md
@@ -34,7 +34,7 @@ $ pre-commit install-hooks
 [INFO] Once installed this environment will be reused.
 [INFO] This may take a few minutes...
 ```
-#### Solution
+#### Solution 1
 For this error you may need to set your global nodenv version
 
 Check the current versions,
@@ -55,6 +55,13 @@ Then inside mymove,
 ~/mymove$ pre-commit install-hooks
 ```
 
+#### Solution 2
+If the above solution does not work, and running the above still results in a hanging or incomplete installation, remove the pre-commit cache and the `.client_deps.stamp` and try again
+
+```shell
+rm -rf ~/.cache/pre-commit
+rm .client_deps.stamp
+```
 
 ### 2. Golang-ci Error: “no go files to analyze”
 For an error about context loading failing, clean your precommit cache.
@@ -129,3 +136,20 @@ Can't run linter goanalysis_metalinter: assign: failed prerequisites: inspect@gi
 ```
 #### Solution
 This could be due to the build failing. Try `make server_build` to check.
+
+#### Nix Error: SSL Certificate verify failed
+
+This can happen because of the way certs need to be handled in this project and `nix`. 
+
+#### Solution
+To get around this issue, you can try running:
+
+```shell
+NIX_SSL_CERT_FILE=$HOME/.nix-profile/etc/ssl/certs/ca-bundle.crt <pre-commit related command>
+```
+
+E.g.
+
+```shell
+NIX_SSL_CERT_FILE=$HOME/.nix-profile/etc/ssl/certs/ca-bundle.crt pre-commit install-hooks
+```


### PR DESCRIPTION
- Removes the 2 isolated precommit troubleshooting sections on the `docs/about/application-setup/dependencies/pre-commit.md` page 
- Integrates the removed precommit troubleshooting sections on to the `docs/backend/guides/troubleshoot-precommit-hook-failures.md` page
- Updates the page where the isolated troubleshooting sections were removed to include a link to the consolidated troubleshooting page for precommits