### PR TITLE
Clarify how we use Pop's TableName method

### DIFF
--- a/docs/backend/setup/database-migrations.md
+++ b/docs/backend/setup/database-migrations.md
@@ -361,9 +361,8 @@ pluralization can be complicated). So, we require a `TableName` method on quite 
 
 Also, note this about the `TableName` method per
 [Pop's documentation](https://gobuffalo.io/documentation/database/models/#using-a-custom-table-name):
-```
-It is recommended to use a value receiver over a pointer receiver if the struct is used as a value anywhere in the code.
-```
+>It is recommended to use a value receiver over a pointer receiver if the struct is used as a value anywhere in the code.
+
 We have run into problems using a pointer receiver for `TableName`, perhpas due to the fact that Pop often treats
 models internally as type `interface{}` in its algorithms, and an
 [interface doesn't play well with pointer receivers](https://stackoverflow.com/questions/40823315/x-does-not-implement-y-method-has-a-pointer-receiver).


### PR DESCRIPTION
In [this milmove PR](https://github.com/transcom/mymove/pull/10224), we started including a `TableName` method on every Pop model to avoid potential issues with the way Pop tries to guess the proper table name.  The doc change in this PR attempts to clarify that we do this and why we do it.