### PR TITLE
[ office-hours ] Adding an update EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+tab_width = 2
+trim_trailing_whitespace = true
+
+[*.{jsx,js}]
+indent_size = 2
+indent_style = space
+
+[*.{go,sql}]
+indent_size = 4
+tab_width = 4
+indent_style = tab


### PR DESCRIPTION
This was never added to the repository, so I copied it from
`transcom/mymove` and modified it to be more relevant for this codebase.

Discovered in #315.

The added benefit here is that anyone with EditorConfig enabled in their
IDE/PDE, will be able to trim space-characters from the end of any files they
interact with.
