### PR TITLE
MB-16460: Add link to prime v2 docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -179,6 +179,7 @@ module.exports = {
             spec: 'https://raw.githubusercontent.com/transcom/mymove/main/swagger/ghc.yaml',
             route: '/api/ghc',
           },
+          // Continue to support existing url for those that have bookmarked this link. We can route this to the oldest supported definition
           {
             spec: 'https://raw.githubusercontent.com/transcom/mymove/main/swagger/prime.yaml',
             route: '/api/prime',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -184,6 +184,14 @@ module.exports = {
             route: '/api/prime',
           },
           {
+            spec: 'https://raw.githubusercontent.com/transcom/mymove/main/swagger/prime.yaml',
+            route: '/api/prime/v1',
+          },
+          {
+            spec: 'https://raw.githubusercontent.com/transcom/mymove/main/swagger/prime_v2.yaml',
+            route: '/api/prime/v2',
+          },
+          {
             spec: 'https://raw.githubusercontent.com/transcom/mymove/main/swagger/support.yaml',
             route: '/api/support',
           },

--- a/sidebars.js
+++ b/sidebars.js
@@ -91,6 +91,11 @@ module.exports = {
         },
         {
           type: 'link',
+          label: 'Prime V2',
+          href: '/api/prime/v2',
+        },
+        {
+          type: 'link',
           label: 'Support',
           href: '/api/support',
         },

--- a/sidebars.js
+++ b/sidebars.js
@@ -86,8 +86,8 @@ module.exports = {
         },
         {
           type: 'link',
-          label: 'Prime',
-          href: '/api/prime',
+          label: 'Prime V1',
+          href: '/api/prime/v1',
         },
         {
           type: 'link',


### PR DESCRIPTION
Added a link to the v2 API docs and added a second link to the v1 docs for url consistency.