### PR TITLE
MB-16460: Add note about prime-api-client only supporting v1 APIs

### DIFF
--- a/docs/api/testing/how-to-test-the-prime-api.md
+++ b/docs/api/testing/how-to-test-the-prime-api.md
@@ -64,6 +64,12 @@ You must have data generated within your database and have the server running.
 
 To interact with the Prime API, we will use a CLI utility called `prime-api-client`. To get command line help:
 
+:::info
+
+The `prime-api-client` currently only supports /v1 APIs. Additional code changes are needed in order to enable support for v2 APIs.
+
+:::
+
 * `go run ./cmd/prime-api-client --help` to see a list of all subcommands and common arguments/flags
 * `go run ./cmd/prime-api-client <subcommand> --help` to see a list of specific arguments/flags for a subcommand
 


### PR DESCRIPTION
# [MB-16460](https://dp3.atlassian.net/browse/MB-16460)

This adds an info admonition to show this information.

![image](https://github.com/transcom/mymove-docs/assets/84742904/f50918e7-49e1-46a1-a4bf-c41237837802)

If there is a better place to document this please let me know.  


[MB-16460]: https://dp3.atlassian.net/browse/MB-16460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ