### PR TITLE
Rename file for consistency

### DIFF
--- a/docs/adrs/0082-use-flipt-feature-flags.md
+++ b/docs/adrs/0082-use-flipt-feature-flags.md
@@ -1,5 +1,5 @@
 ---
-title: 0078 Use Flipt for Feature Flags
+title: 0082 Use Flipt for Feature Flags
 description: Feature Flags enable CI/CD and roll-forward recovery. The question isn't "why?", but "how?"
 ---
 


### PR DESCRIPTION
Renaming the ADR so that there aren't title and numbering conflicts.

<img width="1402" alt="image" src="https://github.com/transcom/mymove-docs/assets/84742904/dd45f079-c9d2-41e4-bc51-77ba0780bfaf">
