### PR TITLE
Remove documentatation references to .go-version

### DIFF
--- a/docs/backend/guides/how-to/upgrade-go-version.md
+++ b/docs/backend/guides/how-to/upgrade-go-version.md
@@ -58,7 +58,6 @@ go version go1.16.4 darwin/amd64
 - Update files with the updated Docker image tag hash and/or Go version:
   - [Example PR](https://github.com/transcom/mymove/pull/10185)
   - Update the Go version number in:
-    - `.go-version`
     - `.tool-versions`
     - `go-version` in `.github/workflows/go-auto-approve.yml`
   - Update the Docker image tag hash in:


### PR DESCRIPTION
As a follow on to https://github.com/transcom/mymove/pull/11126, we need to make sure the docs referencing .go-version are updated. 

Fortunately that was only one place, so this PR removes instructions to update `.go-version` when upgrading the Go version, as it was removed from the repo.