### PR TITLE
MB-12698

### DIFF
--- a/docs/integrations/gex/_category_.json
+++ b/docs/integrations/gex/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "GEX",
+  "collapsed": true
+}

--- a/docs/integrations/gex/index.md
+++ b/docs/integrations/gex/index.md
@@ -1,0 +1,16 @@
+---
+id: index
+slug: /backend/guides/gex
+---
+
+# GEX
+
+GEX stands for Global Exchage. It is the DoD’s Global Exchange system for sending data securely with third parties that are outside of the DoD. For example, MilMove uses GEX to communicate with US Bank’s Syncada to send invoices and receive responses.
+
+GEX only runs in the stg and prod environments.
+
+## Further Information
+
+- [GEX SSH Key Setup](https://dp3.atlassian.net/wiki/spaces/MT/pages/2136899587/DRAFT+GEX+SSH+Key+Setup)
+- [Updating the GEX Connection](https://dp3.atlassian.net/wiki/spaces/MT/pages/2025947223/0068+Updating+GEX+connection)
+- [GEX Account Password Rotation and Management](https://dp3.atlassian.net/wiki/spaces/MT/pages/1775796264/0076+GEX+Account+Password+Rotation+and+Management)

--- a/docs/integrations/gex/testing-ssh-and-sftp-connections-locally.md
+++ b/docs/integrations/gex/testing-ssh-and-sftp-connections-locally.md
@@ -8,17 +8,11 @@ The following sets of steps are best done with a terminal window open in the Mil
 
 ## Setting Up a SSH Server
 
-1. Generate a key pair with `ssh-keygen -f ./test_key_pair -t ecdsa -b 521`
+1. Generate a key pair with `ssh-keygen -f ./tmp/test_key_pair -t ecdsa -b 521`
    :::note
-   You may want to do this inside of the tmp folder since that gets gitignored
+   You may want to do this inside of the MilMove tmp folder since that gets gitignored. This helps avoid accidental commits of private keys.
    :::
-2. Run `make docker_local_ssh_server_with_key`
-   :::note
-   You can also use `make docker_local_ssh_server_with_password`, depending on if you want to test the SSH connection with a key or a password
-   :::
-3. Open the CLI to the Docker container you just made
-4. Inside the CLI for the Docker container `run cat /etc/ssh/ssh_host_ecdsa_key.pub`
-5. Inside of the project's `.envrc.local`; set the following environment variables, the `GEX_SFTP_HOST_KEY` should use the key that you got in step 4.
+2. Inside of the project's `.envrc.local`; set the following environment variables.
 
 ```shell
 export GEX_SFTP_USER_ID=testu
@@ -26,17 +20,25 @@ export GEX_SFTP_PASSWORD=testp
 export GEX_SFTP_IP_ADDRESS=localhost
 export GEX_SFTP_PORT=2222
 export SEND_TO_SYNCADA=true
-export GEX_SFTP_HOST_KEY='this should be the value of what you retrieved from step 4'
 export GEX_PRIVATE_KEY=$(<./tmp/test_key_pair)
 export TEST_GEX_PUBLIC_KEY=$(<./tmp/test_key_pair.pub)
+# export GEX_SFTP_HOST_KEY=$(docker exec sshd cat /etc/ssh/ssh_host_ecdsa_key.pub)
 ```
+
+3. Run `direnv allow`
+4. Run `make docker_local_ssh_server_with_key`
+   :::note
+   You can also use `make docker_local_ssh_server_with_password`, depending on if you want to test the SSH connection with a key or a password
+   :::
+
+5. Uncomment the `export GEX_SFTP_HOST_KEY...` line inside of the `.envrc.local`
 
 ## Testing the Connection
 
 ### Using the Build Tools
 
 1. Run `direnv allow`
-2. Run `make build_tools`
+2. Run `make bin/milmove-tasks`
 3. Run `milmove-tasks connect-to-gex-via-sftp`
 
 ### Testing the SSH Connection Manually
@@ -45,7 +47,8 @@ export TEST_GEX_PUBLIC_KEY=$(<./tmp/test_key_pair.pub)
 To exit from either the SFTP or SSH session, you can type and enter `exit` and you will be taken back to your original terminal session.
 :::
 
-1. Run `ssh -v -i ./tmp/test_key_pair -p 2222 testu@localhost`
+1. Run `direnv allow`
+2. Run `ssh -v -i ./tmp/test_key_pair -p 2222 testu@localhost`
 
 ### Testing the SFTP Connection Manually
 
@@ -53,4 +56,5 @@ To exit from either the SFTP or SSH session, you can type and enter `exit` and y
 To exit from either the SFTP or SSH session, you can type and enter `exit` and you will be taken back to your original terminal session.
 :::
 
-1. Run `sftp -v -P 2222 testu@localhost`
+1. Run `direnv allow`
+2. Run `sftp -v -P 2222 testu@localhost`

--- a/docs/integrations/gex/testing-ssh-and-sftp-connections-locally.md
+++ b/docs/integrations/gex/testing-ssh-and-sftp-connections-locally.md
@@ -1,0 +1,56 @@
+# How to Test a SSH and SFTP Connection Locally
+
+SSH and SFTP is one of the ways that GEX connects to MilMove. The GEX servers can be connected to manually via SSH and SFTP, but that requires setting up a Bastion inside of the staging and production environment.
+
+When doing development on an SSH or SFTP connection, it is much more convenient to be able to test locally. If you are looking to update the SSH or SFTP connection to GEX, testing locally provides an addtional assurance that the code for the connection is written correctly.
+
+The following sets of steps are best done with a terminal window open in the MilMove project repository.
+
+## Setting Up a SSH Server
+
+1. Generate a key pair with `ssh-keygen -f ./test_key_pair -t ecdsa -b 521`
+   :::note
+   You may want to do this inside of the tmp folder since that gets gitignored
+   :::
+2. Run `make docker_local_ssh_server_with_key`
+   :::note
+   You can also use `make docker_local_ssh_server_with_password`, depending on if you want to test the SSH connection with a key or a password
+   :::
+3. Open the CLI to the Docker container you just made
+4. Inside the CLI for the Docker container `run cat /etc/ssh/ssh_host_ecdsa_key.pub`
+5. Inside of the project's `.envrc.local`; set the following environment variables, the `GEX_SFTP_HOST_KEY` should use the key that you got in step 4.
+
+```shell
+export GEX_SFTP_USER_ID=testu
+export GEX_SFTP_PASSWORD=testp
+export GEX_SFTP_IP_ADDRESS=localhost
+export GEX_SFTP_PORT=2222
+export SEND_TO_SYNCADA=true
+export GEX_SFTP_HOST_KEY='this should be the value of what you retrieved from step 4'
+export GEX_PRIVATE_KEY=$(<./tmp/test_key_pair)
+export TEST_GEX_PUBLIC_KEY=$(<./tmp/test_key_pair.pub)
+```
+
+## Testing the Connection
+
+### Using the Build Tools
+
+1. Run `direnv allow`
+2. Run `make build_tools`
+3. Run `milmove-tasks connect-to-gex-via-sftp`
+
+### Testing the SSH Connection Manually
+
+:::note
+To exit from either the SFTP or SSH session, you can type and enter `exit` and you will be taken back to your original terminal session.
+:::
+
+1. Run `ssh -v -i ./tmp/test_key_pair -p 2222 testu@localhost`
+
+### Testing the SFTP Connection Manually
+
+:::note
+To exit from either the SFTP or SSH session, you can type and enter `exit` and you will be taken back to your original terminal session.
+:::
+
+1. Run `sftp -v -P 2222 testu@localhost`

--- a/docs/integrations/gex/troubleshooting-the-gex-connection.md
+++ b/docs/integrations/gex/troubleshooting-the-gex-connection.md
@@ -1,8 +1,4 @@
----
-sidebar_position: 11
----
-
-# Troubleshoot GEX Connection
+# Troubleshooting the GEX Connection
 
 ## 1. Retrieve certificates from chamber
 

--- a/utils/redirect-backend.js
+++ b/utils/redirect-backend.js
@@ -210,12 +210,6 @@ module.exports = [
     ],
   },
   {
-    to: '/docs/backend/guides/troubleshoot-gex-connection',
-    from: [
-      '/docs/help/troubleshoot-gex-connection',
-    ],
-  },
-  {
     to: '/docs/backend/guides/how-to/upgrade-go-version',
     from: [
       '/docs/dev/versioning/upgrade-go-version',


### PR DESCRIPTION
[MB-12698](https://dp3.atlassian.net/browse/MB-12698)

Add documentation on testing sftp and ssh connections locally since it's useful for GEX development.
Move the troubleshooting document on GEX to be under the GEX folder.

[MB-12698]: https://dp3.atlassian.net/browse/MB-12698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ